### PR TITLE
don't zero the IP TOS bits on mbufs that need checksumming

### DIFF
--- a/sys/netinet/tcp_input.c
+++ b/sys/netinet/tcp_input.c
@@ -675,12 +675,14 @@ tcp_input(struct mbuf **mp, int *offp, int proto)
 			/*
 			 * Checksum extended TCP header and data.
 			 */
+			u_int8_t tos = ip->ip_tos;
 			len = off0 + tlen;
 			bzero(ipov->ih_x1, sizeof(ipov->ih_x1));
 			ipov->ih_len = htons(tlen);
 			th->th_sum = in_cksum(m, len);
 			/* Reset length for SDT probes. */
 			ip->ip_len = htons(tlen + off0);
+			ip->ip_tos = tos;
 		}
 
 		if (th->th_sum) {


### PR DESCRIPTION
On mbufs that don't have the CSUM_DATA_VALID flag set, tcp_input()
needs to compute the TCP checksum itself.

The TCP checksum includes some but not all fields from the IP header.

tcp_input() zeroes the fields of the IP header that are not to be
included in the checksum, then checksums the entire packet (IP
header, TCP header, and TCP data), then restores the IP header
fields it will need later.

The bug that this commit fixes is that the IP TOS field was not
restored, so the later read of it returned a zeroed byte instead
of the incoming packet's actual TOS value.
