### PR TITLE
Output strerror from xo_warn

### DIFF
--- a/contrib/libxo/libxo/libxo.c
+++ b/contrib/libxo/libxo/libxo.c
@@ -956,9 +956,6 @@ xo_warn_hcv (xo_handle_t *xop, int code, int check_warn,
     }
     memcpy(newfmt + plen, fmt, len);
 
-    /* Add a newline to the fmt string */
-    if (!(xop->xo_flags & XOF_WARN_XML))
-	newfmt[len++ + plen] = '\n';
     newfmt[len + plen] = '\0';
 
     if (xop->xo_flags & XOF_WARN_XML) {
@@ -1010,6 +1007,7 @@ xo_warn_hcv (xo_handle_t *xop, int code, int check_warn,
 
     } else {
 	vfprintf(stderr, newfmt, vap);
+	fprintf(stderr, ": %s\n", strerror(code));
     }
 }
 


### PR DESCRIPTION
Phabric keeps dropping my diff submissions so I'm putting this here.

Right now xo_warn() causes problems because it doesn't output the error number any longer.

This is what xo_warn should output:

```
/usr/src/lib/libxo % wc /nonexist
wc: /nonexist: open: No such file or directory
```

However libxo is broken and only outputs this:

```
/usr/src/lib/libxo % wc /nonexist         
wc: /nonexist: open
```
