### PR TITLE
ngets shall exit on EOF

### DIFF
--- a/lib/libstand/gets.c
+++ b/lib/libstand/gets.c
@@ -41,11 +41,15 @@ __FBSDID("$FreeBSD$");
 void
 ngets(char *buf, int n)
 {
-    int c;
+    unsigned int c;
     char *lp;
 
-    for (lp = buf;;)
-	switch (c = getchar() & 0177) {
+    for (lp = buf;;) {
+	c = getchar();
+	if (c == -1)
+		break;
+
+	switch (c & 0177) {
 	case '\n':
 	case '\r':
 	    *lp = '\0';
@@ -79,6 +83,7 @@ ngets(char *buf, int n)
 		putchar(c);
 	    }
 	}
+    }
     /*NOTREACHED*/
 }
 


### PR DESCRIPTION
Hi All,

I`ve noted that ngets() from libstand starts consuming CPU like mad when
EOF appears on stdin. I see this issue with bhyveload when forwarding "user input" over pipe.
Here is the simpliest program to reproduce:

cat > ./bget.c
# include <stdint.h>
# include <unistd.h>
# include <stdio.h>
# include <sys/file.h>

int main()
{
        char str[512];

```
    for (;;) {
            ngets(str, sizeof(str));
            if (str[0] == '\n')
                    break;
    }
    return 0;
```

}

$ echo "balbalbalabl" | ./bget &
$ 

You will see bget consuming CPU in ngets() reading EOF, basically because getchar()
returns EOF again and again. Suggested patch fixes the problem.
