### PR TITLE
Remove semicolon on BITSET_DEFINE()

### DIFF
--- a/sys/sys/_bitset.h
+++ b/sys/sys/_bitset.h
@@ -50,7 +50,7 @@
 #define	BITSET_DEFINE(t, _s)						\
 struct t {								\
         long    __bits[__bitset_words((_s))];				\
-};
+}
 
 #define	BITSET_T_INITIALIZER(x)						\
 	{ .__bits = { x } }


### PR DESCRIPTION
This allows/requires callers of BITSET_DEFINE to include a trailing semicolon without introducing a double-semicolon.  This was encountered in _cpuset.h where BITSET_DEFINE(_cpuset, CPU_SETSIZE); on line 50 (rev 23b61e792eee74f3d6bdaf0ec6d265e6c70d7d3d ) results in a compilation error (ISO C does not allow extra ';' outside of a function) when compiling code that calls cpuset.h with the -pedantic-errors flag.