### PR TITLE
Implement xargs -P0: run as many jobs in parallel as possible

### DIFF
--- a/usr.bin/xargs/xargs.1
+++ b/usr.bin/xargs/xargs.1
@@ -206,7 +206,11 @@ Parallel mode: run at most
 .Ar maxprocs
 invocations of
 .Ar utility
-at once.
+at once. If
+.Ar maxprocs
+is negative or 0,
+.Nm
+will run as many processes as possible at a time.
 .It Fl p
 Echo each command to be executed and ask the user whether it should be
 executed.

--- a/usr.bin/xargs/xargs.c
+++ b/usr.bin/xargs/xargs.c
@@ -159,8 +159,11 @@ main(int argc, char *argv[])
 			oflag = 1;
 			break;
 		case 'P':
-			if ((maxprocs = atoi(optarg)) <= 0)
-				errx(1, "max. processes must be >0");
+			maxprocs = strtol(optarg, &endptr, 10);
+			if (*endptr != '\0')
+				errx(1, "max. processes must be a number");
+			if (maxprocs < 1)
+				maxprocs = nargs;
 			break;
 		case 'p':
 			pflag = 1;


### PR DESCRIPTION
This mirrors GNU xargs -P0 feature and increases portability of
scripts that use it. There are a couple of differences though:
 o This change accepts negative numbers as well as 0 to mean the
   same thing, which is consistent with other FreeBSD xargs options
 o This change sets number of parallel commands to maxargs instead
   of some *_MAX macro: this should almost always be what the user
   actually wants to do and increases performance by a lot.

The same patch is uploaded to Bugzilla #199976, which can be
closed if this is merged.