### PR TITLE
Change md device code to use weak symbols as start/end/size for the m…

### DIFF
--- a/sys/conf/Makefile.arm
+++ b/sys/conf/Makefile.arm
@@ -66,10 +66,6 @@ SYSTEM_LD_TAIL +=;sed s/" + SIZEOF_HEADERS"// ldscript.$M\
 		${KERNEL_KO}.bin; \
 		rm ${FULLKERNEL}.noheader
 
-.if defined(MFS_IMAGE)
-SYSTEM_LD_TAIL += ;sh ${S}/tools/embed_mfs.sh ${KERNEL_KO}.bin ${MFS_IMAGE};
-.endif
-
 FILES_CPU_FUNC = \
 	$S/$M/$M/cpufunc_asm_arm9.S \
 	$S/$M/$M/cpufunc_asm_arm10.S \

--- a/sys/conf/kern.post.mk
+++ b/sys/conf/kern.post.mk
@@ -121,7 +121,7 @@ gdbinit:
 .endif
 .endif
 
-${FULLKERNEL}: ${SYSTEM_DEP} vers.o ${MFS_IMAGE}
+${FULLKERNEL}: ${SYSTEM_DEP} vers.o
 	@rm -f ${.TARGET}
 	@echo linking ${.TARGET}
 	${SYSTEM_LD}
@@ -133,9 +133,6 @@ ${FULLKERNEL}: ${SYSTEM_DEP} vers.o ${MFS_IMAGE}
 	${OBJCOPY} --strip-debug ${.TARGET}
 .endif
 	${SYSTEM_LD_TAIL}
-.if defined(MFS_IMAGE)
-	sh ${S}/tools/embed_mfs.sh ${FULLKERNEL} ${MFS_IMAGE}
-.endif
 
 .if !exists(${.OBJDIR}/.depend)
 ${SYSTEM_OBJS}: assym.s vnode_if.h ${BEFORE_DEPEND:M*.h} ${MFILES:T:S/.m$/.h/}
@@ -300,6 +297,27 @@ vnode_if_newproto.h:
 	${AWK} -f $S/tools/vnode_if.awk $S/kern/vnode_if.src -p
 vnode_if_typedef.h:
 	${AWK} -f $S/tools/vnode_if.awk $S/kern/vnode_if.src -q
+
+.if ${MFS_IMAGE:Uno} != "no"
+# Generate an object file from the file system image to embed in the kernel
+# via linking. Make sure the contents are in the mfs section and rename the
+# start/end/size variables to __start_mfs, __stop_mfs, and mfs_size,
+# respectively.
+embedfs_${MFS_IMAGE:T:R}.o: ${MFS_IMAGE}
+	${OBJCOPY} --input-target binary \
+	    --output-target ${EMBEDFS_FORMAT.${MACHINE_CPUARCH}} \
+	    --binary-architecture ${EMBEDFS_ARCH.${MACHINE_CPUARCH}} \
+	    ${MFS_IMAGE} ${.TARGET}
+	${OBJCOPY} \
+	    --rename-section .data=mfs,contents,alloc,load,readonly,data \
+	    --redefine-sym \
+		_binary_${MFS_IMAGE:C,[^[:alnum:]],_,g}_size=mfs_size \
+	    --redefine-sym \
+		_binary_${MFS_IMAGE:C,[^[:alnum:]],_,g}_start=__start_mfs \
+	    --redefine-sym \
+		_binary_${MFS_IMAGE:C,[^[:alnum:]],_,g}_end=__stop_mfs \
+	    ${.TARGET}
+.endif
 
 # XXX strictly, everything depends on Makefile because changes to ${PROF}
 # only appear there, but we don't handle that.

--- a/sys/conf/kern.pre.mk
+++ b/sys/conf/kern.pre.mk
@@ -191,6 +191,9 @@ SYSTEM_DEP= Makefile ${SYSTEM_OBJS}
 SYSTEM_OBJS= locore.o ${MDOBJS} ${OBJS}
 SYSTEM_OBJS+= ${SYSTEM_CFILES:.c=.o}
 SYSTEM_OBJS+= hack.So
+.if ${MFS_IMAGE:Uno} != "no"
+SYSTEM_OBJS+= embedfs_${MFS_IMAGE:T:R}.o
+.endif
 SYSTEM_LD= @${LD} -Bdynamic -T ${LDSCRIPT} ${_LDFLAGS} --no-warn-mismatch \
 	--warn-common --export-dynamic --dynamic-linker /red/herring \
 	-o ${.TARGET} -X ${SYSTEM_OBJS} vers.o
@@ -214,6 +217,15 @@ MKMODULESENV+=	MODULES_OVERRIDE="${MODULES_OVERRIDE}"
 .if defined(DEBUG)
 MKMODULESENV+=	DEBUG_FLAGS="${DEBUG}"
 .endif
+
+# Architecture format argument for objdump to convert image to object file
+EMBEDFS_FORMAT.i386?=		elf32-i386-freebsd
+EMBEDFS_FORMAT.amd64?=		elf64-x86-64-freebsd
+EMBEDFS_FORMAT.arm?=		elf32-littlearm
+EMBEDFS_FORMAT.powerpc?=	elf32-powerpc
+
+EMBEDFS_ARCH.amd64?=		i386
+EMBEDFS_ARCH.${MACHINE_ARCH}?=	${MACHINE_ARCH}
 
 # Detect kernel config options that force stack frames to be turned on.
 DDB_ENABLED!=	grep DDB opt_ddb.h || true ; echo


### PR DESCRIPTION
…d root

  file system in a .mfs section to be a placeholder for relinking with the
  real file system.

Add rules and variable settings in kern.pre.mk and kern.post.mk to handle
  embedding a file system using objcopy to generate a .o file and letting
  the kernel target link with the other object files.

Submitted by:		Steve Kiernan <stevek@juniper.net>
Obtained from:		Juniper Networks, Inc.