### PR TITLE
Add MD_VERIFY option to enable O_VERIFY in open for vnode type.

### DIFF
--- a/sbin/mdconfig/mdconfig.8
+++ b/sbin/mdconfig/mdconfig.8
@@ -208,6 +208,11 @@ Disable/enable extra sanity checks to prevent the user from doing something
 that might adversely affect the system.
 .It Oo Cm no Oc Ns Cm readonly
 Enable/disable readonly mode.
+.It Oo Cm no Oc Ns Cm verify
+For
+.Cm vnode
+backed devices: enable/disable verifying signature of file used for
+backingstore.
 .El
 .It Fl u Ar unit
 Request a specific unit number or device name for the

--- a/sbin/mdconfig/mdconfig.c
+++ b/sbin/mdconfig/mdconfig.c
@@ -193,6 +193,10 @@ main(int argc, char **argv)
 				mdio.md_options |= MD_RESERVE;
 			else if (!strcmp(optarg, "noreserve"))
 				mdio.md_options &= ~MD_RESERVE;
+			else if (!strcmp(optarg, "verify"))
+				mdio.md_options |= MD_VERIFY;
+			else if (!strcmp(optarg, "noverify"))
+				mdio.md_options &= ~MD_VERIFY;
 			else
 				errx(1, "unknown option: %s", optarg);
 			break;

--- a/sbin/mount/mount.c
+++ b/sbin/mount/mount.c
@@ -115,6 +115,7 @@ static struct opt {
 	{ MNT_NFS4ACLS,		"nfsv4acls" },
 	{ MNT_GJOURNAL,		"gjournal" },
 	{ MNT_AUTOMOUNTED,	"automounted" },
+	{ MNT_VERIFIED,		"verified" },
 	{ 0, NULL }
 };
 

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -214,6 +214,7 @@ iso_mountfs(devvp, mp)
 	int iso_bsize;
 	int iso_blknum;
 	int joliet_level;
+	int isverified = 0;
 	struct iso_volume_descriptor *vdp = NULL;
 	struct iso_primary_descriptor *pri = NULL;
 	struct iso_sierra_primary_descriptor *pri_sierra = NULL;
@@ -229,6 +230,8 @@ iso_mountfs(devvp, mp)
 	DROP_GIANT();
 	g_topology_lock();
 	error = g_vfs_open(devvp, &cp, "cd9660", 0);
+	if (error == 0)
+		g_getattr("MNT::verified", cp, &isverified);
 	g_topology_unlock();
 	PICKUP_GIANT();
 	VOP_UNLOCK(devvp, 0);
@@ -378,6 +381,8 @@ iso_mountfs(devvp, mp)
 	mp->mnt_stat.f_fsid.val[1] = mp->mnt_vfc->vfc_typenum;
 	mp->mnt_maxsymlinklen = 0;
 	MNT_ILOCK(mp);
+	if (isverified)
+		mp->mnt_flag |= MNT_VERIFIED;
 	mp->mnt_flag |= MNT_LOCAL;
 	mp->mnt_kern_flag |= MNTK_LOOKUP_SHARED | MNTK_EXTENDED_SHARED;
 	MNT_IUNLOCK(mp);

--- a/sys/sys/mdioctl.h
+++ b/sys/sys/mdioctl.h
@@ -81,12 +81,13 @@ struct md_ioctl {
 #define MDIOCLIST	_IOWR('m', 3, struct md_ioctl)	/* query status */
 #define MDIOCRESIZE	_IOWR('m', 4, struct md_ioctl)	/* resize disk */
 
-#define MD_CLUSTER	0x01	/* Don't cluster */
-#define MD_RESERVE	0x02	/* Pre-reserve swap */
-#define MD_AUTOUNIT	0x04	/* Assign next free unit */
-#define MD_READONLY	0x08	/* Readonly mode */
-#define MD_COMPRESS	0x10	/* Compression mode */
-#define MD_FORCE	0x20	/* Don't try to prevent foot-shooting */
-#define MD_ASYNC	0x40	/* Asynchronous mode */
+#define MD_CLUSTER	0x0001	/* Don't cluster */
+#define MD_RESERVE	0x0002	/* Pre-reserve swap */
+#define MD_AUTOUNIT	0x0004	/* Assign next free unit */
+#define MD_READONLY	0x0008	/* Readonly mode */
+#define MD_COMPRESS	0x0010	/* Compression mode */
+#define MD_FORCE	0x0020	/* Don't try to prevent foot-shooting */
+#define MD_ASYNC	0x0040	/* Asynchronous mode */
+#define MD_VERIFY	0x0100	/* Open file with O_VERIFY (vnode only) */
 
 #endif	/* _SYS_MDIOCTL_H_*/

--- a/sys/sys/mount.h
+++ b/sys/sys/mount.h
@@ -282,6 +282,7 @@ void          __mnt_vnode_markerfree_active(struct vnode **mvp, struct mount *);
 #define	MNT_ROOTFS	0x0000000000004000ULL /* identifies the root fs */
 #define	MNT_USER	0x0000000000008000ULL /* mounted by a user */
 #define	MNT_IGNORE	0x0000000000800000ULL /* do not show entry in df */
+#define	MNT_VERIFIED	0x0000000400000000ULL /* filesystem is verified */
 
 /*
  * Mask of flags that are visible to statfs().
@@ -297,7 +298,7 @@ void          __mnt_vnode_markerfree_active(struct vnode **mvp, struct mount *);
 			MNT_NOCLUSTERW	| MNT_SUIDDIR	| MNT_SOFTDEP	| \
 			MNT_IGNORE	| MNT_EXPUBLIC	| MNT_NOSYMFOLLOW | \
 			MNT_GJOURNAL	| MNT_MULTILABEL | MNT_ACLS	| \
-			MNT_NFS4ACLS	| MNT_AUTOMOUNTED)
+			MNT_NFS4ACLS	| MNT_AUTOMOUNTED | MNT_VERIFIED)
 
 /* Mask of flags that can be updated. */
 #define	MNT_UPDATEMASK (MNT_NOSUID	| MNT_NOEXEC	| \


### PR DESCRIPTION
Add -o [no]verify option to mdconfig (and document in man page.)
Implement GEOM attribute MNT::verified to ask md if the backing vnode is
  verified.

Submitted by:		Steve Kiernan <stevek@juniper.net>
Obtained from:		Juniper Networks, Inc.