### PR TITLE
Add blackhole(4) documentation for SCTP

### DIFF
--- a/share/man/man4/blackhole.4
+++ b/share/man/man4/blackhole.4
@@ -11,30 +11,36 @@
 .\"    documentation and/or other materials provided with the distribution.
 .\"
 .\"
-.\" $FreeBSD$
-.Dd September 5, 2015
+.\" $FreeBSD: head/share/man/man4/blackhole.4 210676 2010-07-31 12:14:28Z joel $
+.Dd September 6, 2015
 .Dt BLACKHOLE 4
 .Os
 .Sh NAME
 .Nm blackhole
 .Nd a
 .Xr sysctl 8
-MIB for manipulating behaviour in respect of refused TCP, UDP, or SCTP connection
+MIB for manipulating behaviour in respect of refused SCTP, TCP, or UDP connection
 attempts
 .Sh SYNOPSIS
-.Cd sysctl net.inet.sctp.blackhole Ns
-.Op =[ 0 | 1 ]
-.Cd sysctl net.inet.tcp.blackhole Ns
-.Op =[ 0 | 1 | 2 ] 
-.Cd sysctl net.inet.udp.blackhole Ns
-.Op =[ 0 | 1 ]
+.Cd sysctl net.inet.sctp.blackhole Ns Op = Ns Brq "0 | 1 | 2"
+.Cd sysctl net.inet.tcp.blackhole Ns Op = Ns Brq "0 | 1 | 2"
+.Cd sysctl net.inet.udp.blackhole Ns Op = Ns Brq "0 | 1"
 .Sh DESCRIPTION
 The
 .Nm
 .Xr sysctl 8
 MIB is used to control system behaviour when connection requests
-are received on TCP, UDP, or SCTP ports where there is no socket listening.
+are received on SCTP, TCP, or UDP ports where there is no socket listening.
 .Pp
+The blackhole behaviour is useful to slow down an attacker who is port-scanning
+a system in an attempt to detect vulnerable services.
+It might also slow down an attempted denial of service attack.
+.Ss SCTP
+Setting the SCTP blackhole MIB to a numeric value of one
+will prevent sending an ABORT packet in response to an incoming INIT.
+A MIB value of two will do the same, but will also prevent sending an ABORT packet
+when unexpected packets are received.
+.Ss TCP
 Normal behaviour, when a TCP SYN segment is received on a port where
 there is no socket accepting connections, is for the system to return
 a RST segment, and drop the connection.
@@ -48,25 +54,13 @@ as a blackhole.
 By setting the MIB value to two, any segment arriving
 on a closed port is dropped without returning a RST.
 This provides some degree of protection against stealth port scans.
-.Pp
-In the UDP instance, enabling blackhole behaviour turns off the sending
+.Ss UDP
+Enabling blackhole behaviour turns off the sending
 of an ICMP port unreachable message in response to a UDP datagram which
 arrives on a port where there is no socket listening.
 It must be noted that this behaviour will prevent remote systems from running
 .Xr traceroute 8
 to a system.
-.Pp
-For SCTP, enabling blackhole behaviour turns off the sending of ABORT packets
-as follows:
-A MIB value of one will prevent sending an ABORT packet
-in response to an incoming INIT.
-A MIB value of two will do the same, but also prevent sending an ABORT packet
-when unexpected packets are received.
-.Pp
-The blackhole behaviour is useful to slow down anyone who is port scanning
-a system, attempting to detect vulnerable services on a system.
-It could potentially also slow down someone who is attempting a denial
-of service attack.
 .Sh WARNING
 The SCTP, TCP, and UDP blackhole features should not be regarded as a replacement
 for firewall solutions.

--- a/share/man/man4/blackhole.4
+++ b/share/man/man4/blackhole.4
@@ -12,25 +12,28 @@
 .\"
 .\"
 .\" $FreeBSD$
-.Dd January 1, 2007
+.Dd September 5, 2015
 .Dt BLACKHOLE 4
 .Os
 .Sh NAME
 .Nm blackhole
 .Nd a
 .Xr sysctl 8
-MIB for manipulating behaviour in respect of refused TCP, UDP or SCTP connection
+MIB for manipulating behaviour in respect of refused TCP, UDP, or SCTP connection
 attempts
 .Sh SYNOPSIS
-.Cd sysctl net.inet.sctp.blackhole[=[0|1]]
-.Cd sysctl net.inet.tcp.blackhole[=[0|1|2]]
-.Cd sysctl net.inet.udp.blackhole[=[0|1]]
+.Cd sysctl net.inet.sctp.blackhole Ns
+.Op =[ 0 | 1 ]
+.Cd sysctl net.inet.tcp.blackhole Ns
+.Op =[ 0 | 1 | 2 ] 
+.Cd sysctl net.inet.udp.blackhole Ns
+.Op =[ 0 | 1 ]
 .Sh DESCRIPTION
 The
 .Nm
 .Xr sysctl 8
 MIB is used to control system behaviour when connection requests
-are received on TCP, UDP or SCTP ports where there is no socket listening.
+are received on TCP, UDP, or SCTP ports where there is no socket listening.
 .Pp
 Normal behaviour, when a TCP SYN segment is received on a port where
 there is no socket accepting connections, is for the system to return
@@ -54,16 +57,18 @@ It must be noted that this behaviour will prevent remote systems from running
 to a system.
 .Pp
 For SCTP, enabling blackhole behaviour turns off the sending of ABORT packets
-as follows: A MIB value of one will prevent sending an ABORT packet
-in response to an incoming INIT. A MIB value of two will do the same, but also
-prevent sending an ABORT packet when receiving packets out of the blue.
+as follows:
+A MIB value of one will prevent sending an ABORT packet
+in response to an incoming INIT.
+A MIB value of two will do the same, but also prevent sending an ABORT packet
+when unexpected packets are received.
 .Pp
 The blackhole behaviour is useful to slow down anyone who is port scanning
 a system, attempting to detect vulnerable services on a system.
 It could potentially also slow down someone who is attempting a denial
 of service attack.
 .Sh WARNING
-The SCTP, TCP and UDP blackhole features should not be regarded as a replacement
+The SCTP, TCP, and UDP blackhole features should not be regarded as a replacement
 for firewall solutions.
 Better security would consist of the
 .Nm

--- a/share/man/man4/blackhole.4
+++ b/share/man/man4/blackhole.4
@@ -19,17 +19,18 @@
 .Nm blackhole
 .Nd a
 .Xr sysctl 8
-MIB for manipulating behaviour in respect of refused TCP or UDP connection
+MIB for manipulating behaviour in respect of refused TCP, UDP or SCTP connection
 attempts
 .Sh SYNOPSIS
-.Cd sysctl net.inet.tcp.blackhole[=[0 | 1 | 2]]
-.Cd sysctl net.inet.udp.blackhole[=[0 | 1]]
+.Cd sysctl net.inet.sctp.blackhole[=[0|1]]
+.Cd sysctl net.inet.tcp.blackhole[=[0|1|2]]
+.Cd sysctl net.inet.udp.blackhole[=[0|1]]
 .Sh DESCRIPTION
 The
 .Nm
 .Xr sysctl 8
 MIB is used to control system behaviour when connection requests
-are received on TCP or UDP ports where there is no socket listening.
+are received on TCP, UDP or SCTP ports where there is no socket listening.
 .Pp
 Normal behaviour, when a TCP SYN segment is received on a port where
 there is no socket accepting connections, is for the system to return
@@ -52,12 +53,17 @@ It must be noted that this behaviour will prevent remote systems from running
 .Xr traceroute 8
 to a system.
 .Pp
+For SCTP, enabling blackhole behaviour turns off the sending of ABORT packets
+as follows: A MIB value of one will prevent sending an ABORT packet
+in response to an incoming INIT. A MIB value of two will do the same, but also
+prevent sending an ABORT packet when receiving packets out of the blue.
+.Pp
 The blackhole behaviour is useful to slow down anyone who is port scanning
 a system, attempting to detect vulnerable services on a system.
 It could potentially also slow down someone who is attempting a denial
 of service attack.
 .Sh WARNING
-The TCP and UDP blackhole features should not be regarded as a replacement
+The SCTP, TCP and UDP blackhole features should not be regarded as a replacement
 for firewall solutions.
 Better security would consist of the
 .Nm
@@ -68,6 +74,7 @@ This mechanism is not a substitute for securing a system.
 It should be used together with other security mechanisms.
 .Sh SEE ALSO
 .Xr ip 4 ,
+.Xr sctp 4 ,
 .Xr tcp 4 ,
 .Xr udp 4 ,
 .Xr ipf 8 ,
@@ -80,5 +87,10 @@ The TCP and UDP
 MIBs
 first appeared in
 .Fx 4.0 .
+.Pp
+The SCTP 
+.Nm 
+MIB first appeared in
+.Fx 9.1 .
 .Sh AUTHORS
 .An Geoffrey M. Rehmet

--- a/sys/netinet/sctp_sysctl.h
+++ b/sys/netinet/sctp_sysctl.h
@@ -545,7 +545,7 @@ struct sctp_sysctl {
 #define SCTPCTL_RTTVAR_DCCCECN_MAX	1
 #define SCTPCTL_RTTVAR_DCCCECN_DEFAULT	1	/* 0 means disable feature */
 
-#define SCTPCTL_BLACKHOLE_DESC		"Enable SCTP blackholing"
+#define SCTPCTL_BLACKHOLE_DESC		"Enable SCTP blackholing. See blackhole(4) man page for more details."
 #define SCTPCTL_BLACKHOLE_MIN		0
 #define SCTPCTL_BLACKHOLE_MAX		2
 #define SCTPCTL_BLACKHOLE_DEFAULT	SCTPCTL_BLACKHOLE_MIN

--- a/sys/netinet/sctp_sysctl.h
+++ b/sys/netinet/sctp_sysctl.h
@@ -291,10 +291,10 @@ struct sctp_sysctl {
 #define SCTPCTL_PMTU_RAISE_TIME_DEFAULT	SCTP_DEF_PMTU_RAISE_SEC
 
 /* shutdown_guard_time: Default shutdown guard timer in seconds */
-#define SCTPCTL_SHUTDOWN_GUARD_TIME_DESC	"Default shutdown guard timer in seconds"
+#define SCTPCTL_SHUTDOWN_GUARD_TIME_DESC	"Shutdown guard timer in seconds (0 means 5 times RTO.Max)"
 #define SCTPCTL_SHUTDOWN_GUARD_TIME_MIN		0
 #define SCTPCTL_SHUTDOWN_GUARD_TIME_MAX		0xFFFFFFFF
-#define SCTPCTL_SHUTDOWN_GUARD_TIME_DEFAULT	SCTP_DEF_MAX_SHUTDOWN_SEC
+#define SCTPCTL_SHUTDOWN_GUARD_TIME_DEFAULT	0
 
 /* secret_lifetime: Default secret lifetime in seconds */
 #define SCTPCTL_SECRET_LIFETIME_DESC	"Default secret lifetime in seconds"
@@ -545,7 +545,7 @@ struct sctp_sysctl {
 #define SCTPCTL_RTTVAR_DCCCECN_MAX	1
 #define SCTPCTL_RTTVAR_DCCCECN_DEFAULT	1	/* 0 means disable feature */
 
-#define SCTPCTL_BLACKHOLE_DESC		"Enable SCTP blackholing. See blackhole(4) man page for more details."
+#define SCTPCTL_BLACKHOLE_DESC		"Enable SCTP blackholing. See blackhole(4) for more details."
 #define SCTPCTL_BLACKHOLE_MIN		0
 #define SCTPCTL_BLACKHOLE_MAX		2
 #define SCTPCTL_BLACKHOLE_DEFAULT	SCTPCTL_BLACKHOLE_MIN


### PR DESCRIPTION
Documented the sysctl MIB net.inet.sctp.blackhole in blackhole(4) man page, and updated MIB description to refer to said man page.

Also adjusted formatting under SYNOPSIS while here, to prevent cluttered line breaks in middle of optional parameters.

Relates to bugzilla ID 184110 (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=184110)