### PR TITLE
Add support TCO v3 and bunch of PCI IDs of Intel new chipsets

### DIFF
--- a/sys/dev/ichwd/ichwd.c
+++ b/sys/dev/ichwd/ichwd.c
@@ -53,6 +53,7 @@
  * (document no. 252516-001) sections 9.10 and 9.11.
  *
  * ICH6/7/8 support by Takeharu KATO <takeharu1219@ybb.ne.jp>
+ * SoC PMC support by Denir Li <denir.li@cas-well.com>
  */
 
 #include <sys/cdefs.h>
@@ -74,161 +75,216 @@ __FBSDID("$FreeBSD$");
 #include <dev/ichwd/ichwd.h>
 
 static struct ichwd_device ichwd_devices[] = {
-	{ DEVICEID_82801AA,  "Intel 82801AA watchdog timer",	1 },
-	{ DEVICEID_82801AB,  "Intel 82801AB watchdog timer",	1 },
-	{ DEVICEID_82801BA,  "Intel 82801BA watchdog timer",	2 },
-	{ DEVICEID_82801BAM, "Intel 82801BAM watchdog timer",	2 },
-	{ DEVICEID_82801CA,  "Intel 82801CA watchdog timer",	3 },
-	{ DEVICEID_82801CAM, "Intel 82801CAM watchdog timer",	3 },
-	{ DEVICEID_82801DB,  "Intel 82801DB watchdog timer",	4 },
-	{ DEVICEID_82801DBM, "Intel 82801DBM watchdog timer",	4 },
-	{ DEVICEID_82801E,   "Intel 82801E watchdog timer",	5 },
-	{ DEVICEID_82801EB,  "Intel 82801EB watchdog timer",	5 },
-	{ DEVICEID_82801EBR, "Intel 82801EB/ER watchdog timer",	5 },
-	{ DEVICEID_6300ESB,  "Intel 6300ESB watchdog timer",	5 },
-	{ DEVICEID_82801FBR, "Intel 82801FB/FR watchdog timer",	6 },
-	{ DEVICEID_ICH6M,    "Intel ICH6M watchdog timer",	6 },
-	{ DEVICEID_ICH6W,    "Intel ICH6W watchdog timer",	6 },
-	{ DEVICEID_ICH7,     "Intel ICH7 watchdog timer",	7 },
-	{ DEVICEID_ICH7DH,   "Intel ICH7DH watchdog timer",	7 },
-	{ DEVICEID_ICH7M,    "Intel ICH7M watchdog timer",	7 },
-	{ DEVICEID_ICH7MDH,  "Intel ICH7MDH watchdog timer",	7 },
-	{ DEVICEID_NM10,     "Intel NM10 watchdog timer",	7 },
-	{ DEVICEID_ICH8,     "Intel ICH8 watchdog timer",	8 },
-	{ DEVICEID_ICH8DH,   "Intel ICH8DH watchdog timer",	8 },
-	{ DEVICEID_ICH8DO,   "Intel ICH8DO watchdog timer",	8 },
-	{ DEVICEID_ICH8M,    "Intel ICH8M watchdog timer",	8 },
-	{ DEVICEID_ICH8ME,   "Intel ICH8M-E watchdog timer",	8 },
-	{ DEVICEID_63XXESB,  "Intel 63XXESB watchdog timer",	8 },
-	{ DEVICEID_ICH9,     "Intel ICH9 watchdog timer",	9 },
-	{ DEVICEID_ICH9DH,   "Intel ICH9DH watchdog timer",	9 },
-	{ DEVICEID_ICH9DO,   "Intel ICH9DO watchdog timer",	9 },
-	{ DEVICEID_ICH9M,    "Intel ICH9M watchdog timer",	9 },
-	{ DEVICEID_ICH9ME,   "Intel ICH9M-E watchdog timer",	9 },
-	{ DEVICEID_ICH9R,    "Intel ICH9R watchdog timer",	9 },
-	{ DEVICEID_ICH10,    "Intel ICH10 watchdog timer",	10 },
-	{ DEVICEID_ICH10D,   "Intel ICH10D watchdog timer",	10 },
-	{ DEVICEID_ICH10DO,  "Intel ICH10DO watchdog timer",	10 },
-	{ DEVICEID_ICH10R,   "Intel ICH10R watchdog timer",	10 },
-	{ DEVICEID_PCH,      "Intel PCH watchdog timer",	10 },
-	{ DEVICEID_PCHM,     "Intel PCH watchdog timer",	10 },
-	{ DEVICEID_P55,      "Intel P55 watchdog timer",	10 },
-	{ DEVICEID_PM55,     "Intel PM55 watchdog timer",	10 },
-	{ DEVICEID_H55,      "Intel H55 watchdog timer",	10 },
-	{ DEVICEID_QM57,     "Intel QM57 watchdog timer",       10 },
-	{ DEVICEID_H57,      "Intel H57 watchdog timer",        10 },
-	{ DEVICEID_HM55,     "Intel HM55 watchdog timer",       10 },
-	{ DEVICEID_Q57,      "Intel Q57 watchdog timer",        10 },
-	{ DEVICEID_HM57,     "Intel HM57 watchdog timer",       10 },
-	{ DEVICEID_PCHMSFF,  "Intel PCHMSFF watchdog timer",    10 },
-	{ DEVICEID_QS57,     "Intel QS57 watchdog timer",       10 },
-	{ DEVICEID_3400,     "Intel 3400 watchdog timer",       10 },
-	{ DEVICEID_3420,     "Intel 3420 watchdog timer",       10 },
-	{ DEVICEID_3450,     "Intel 3450 watchdog timer",       10 },
-	{ DEVICEID_CPT0,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT1,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT2,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT3,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT4,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT5,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT6,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT7,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT8,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT9,     "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT10,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT11,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT12,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT13,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT14,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT15,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT16,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT17,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT18,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT19,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT20,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT21,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT22,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT23,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT23,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT25,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT26,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT27,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT28,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT29,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT30,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_CPT31,    "Intel Cougar Point watchdog timer",	10 },
-	{ DEVICEID_PATSBURG_LPC1, "Intel Patsburg watchdog timer",	10 },
-	{ DEVICEID_PATSBURG_LPC2, "Intel Patsburg watchdog timer",	10 },
-	{ DEVICEID_PPT0,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT1,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT2,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT3,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT4,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT5,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT6,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT7,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT8,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT9,     "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT10,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT11,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT12,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT13,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT14,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT15,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT16,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT17,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT18,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT19,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT20,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT21,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT22,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT23,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT24,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT25,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT26,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT27,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT28,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT29,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT30,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_PPT31,    "Intel Panther Point watchdog timer",	10 },
-	{ DEVICEID_LPT0,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT1,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT2,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT3,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT4,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT5,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT6,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT7,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT8,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT9,     "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT10,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT11,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT12,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT13,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT14,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT15,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT16,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT17,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT18,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT19,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT20,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT21,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT22,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT23,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT24,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT25,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT26,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT27,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT28,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT29,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT30,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_LPT31,    "Intel Lynx Point watchdog timer",		10 },
-	{ DEVICEID_WCPT2,    "Intel Wildcat Point watchdog timer",	10 },
-	{ DEVICEID_WCPT4,    "Intel Wildcat Point watchdog timer",	10 },
-	{ DEVICEID_WCPT6,    "Intel Wildcat Point watchdog timer",	10 },
-	{ DEVICEID_DH89XXCC_LPC,  "Intel DH89xxCC watchdog timer",	10 },
-	{ DEVICEID_COLETOCRK_LPC, "Intel Coleto Creek watchdog timer",  10 },
-	{ 0, NULL, 0 },
+	{ DEVICEID_82801AA,  "Intel 82801AA watchdog timer",	1, 1 },
+	{ DEVICEID_82801AB,  "Intel 82801AB watchdog timer",	1, 1 },
+	{ DEVICEID_82801BA,  "Intel 82801BA watchdog timer",	2, 1 },
+	{ DEVICEID_82801BAM, "Intel 82801BAM watchdog timer",	2, 1 },
+	{ DEVICEID_82801CA,  "Intel 82801CA watchdog timer",	3, 1 },
+	{ DEVICEID_82801CAM, "Intel 82801CAM watchdog timer",	3, 1 },
+	{ DEVICEID_82801DB,  "Intel 82801DB watchdog timer",	4, 1 },
+	{ DEVICEID_82801DBM, "Intel 82801DBM watchdog timer",	4, 1 },
+	{ DEVICEID_82801E,   "Intel 82801E watchdog timer",	5, 1 },
+	{ DEVICEID_82801EB,  "Intel 82801EB watchdog timer",	5, 1 },
+	{ DEVICEID_82801EBR, "Intel 82801EB/ER watchdog timer",	5, 1 },
+	{ DEVICEID_6300ESB,  "Intel 6300ESB watchdog timer",	5, 1 },
+	{ DEVICEID_82801FBR, "Intel 82801FB/FR watchdog timer",	6, 2 },
+	{ DEVICEID_ICH6M,    "Intel ICH6M watchdog timer",	6, 2 },
+	{ DEVICEID_ICH6W,    "Intel ICH6W watchdog timer",	6, 2 },
+	{ DEVICEID_ICH7,     "Intel ICH7 watchdog timer",	7, 2 },
+	{ DEVICEID_ICH7DH,   "Intel ICH7DH watchdog timer",	7, 2 },
+	{ DEVICEID_ICH7M,    "Intel ICH7M watchdog timer",	7, 2 },
+	{ DEVICEID_ICH7MDH,  "Intel ICH7MDH watchdog timer",	7, 2 },
+	{ DEVICEID_NM10,     "Intel NM10 watchdog timer",	7, 2 },
+	{ DEVICEID_ICH8,     "Intel ICH8 watchdog timer",	8, 2 },
+	{ DEVICEID_ICH8DH,   "Intel ICH8DH watchdog timer",	8, 2 },
+	{ DEVICEID_ICH8DO,   "Intel ICH8DO watchdog timer",	8, 2 },
+	{ DEVICEID_ICH8M,    "Intel ICH8M watchdog timer",	8, 2 },
+	{ DEVICEID_ICH8ME,   "Intel ICH8M-E watchdog timer",	8, 2 },
+	{ DEVICEID_63XXESB,  "Intel 63XXESB watchdog timer",	8, 2 },
+	{ DEVICEID_ICH9,     "Intel ICH9 watchdog timer",	9, 2 },
+	{ DEVICEID_ICH9DH,   "Intel ICH9DH watchdog timer",	9, 2 },
+	{ DEVICEID_ICH9DO,   "Intel ICH9DO watchdog timer",	9, 2 },
+	{ DEVICEID_ICH9M,    "Intel ICH9M watchdog timer",	9, 2 },
+	{ DEVICEID_ICH9ME,   "Intel ICH9M-E watchdog timer",	9, 2 },
+	{ DEVICEID_ICH9R,    "Intel ICH9R watchdog timer",	9, 2 },
+	{ DEVICEID_ICH10,    "Intel ICH10 watchdog timer",	10, 2 },
+	{ DEVICEID_ICH10D,   "Intel ICH10D watchdog timer",	10, 2 },
+	{ DEVICEID_ICH10DO,  "Intel ICH10DO watchdog timer",	10, 2 },
+	{ DEVICEID_ICH10R,   "Intel ICH10R watchdog timer",	10, 2 },
+	{ DEVICEID_PCH,      "Intel PCH watchdog timer",	10, 2 },
+	{ DEVICEID_PCHM,     "Intel PCH watchdog timer",	10, 2 },
+	{ DEVICEID_P55,      "Intel P55 watchdog timer",	10, 2 },
+	{ DEVICEID_PM55,     "Intel PM55 watchdog timer",	10, 2 },
+	{ DEVICEID_H55,      "Intel H55 watchdog timer",	10, 2 },
+	{ DEVICEID_QM57,     "Intel QM57 watchdog timer",       10, 2 },
+	{ DEVICEID_H57,      "Intel H57 watchdog timer",        10, 2 },
+	{ DEVICEID_HM55,     "Intel HM55 watchdog timer",       10, 2 },
+	{ DEVICEID_Q57,      "Intel Q57 watchdog timer",        10, 2 },
+	{ DEVICEID_HM57,     "Intel HM57 watchdog timer",       10, 2 },
+	{ DEVICEID_PCHMSFF,  "Intel PCHMSFF watchdog timer",    10, 2 },
+	{ DEVICEID_QS57,     "Intel QS57 watchdog timer",       10, 2 },
+	{ DEVICEID_3400,     "Intel 3400 watchdog timer",       10, 2 },
+	{ DEVICEID_3420,     "Intel 3420 watchdog timer",       10, 2 },
+	{ DEVICEID_3450,     "Intel 3450 watchdog timer",       10, 2 },
+	{ DEVICEID_CPT0,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT1,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT2,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT3,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT4,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT5,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT6,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT7,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT8,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT9,     "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT10,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT11,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT12,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT13,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT14,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT15,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT16,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT17,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT18,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT19,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT20,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT21,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT22,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT23,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT23,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT25,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT26,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT27,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT28,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT29,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT30,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_CPT31,    "Intel Cougar Point watchdog timer",	10, 2 },
+	{ DEVICEID_PATSBURG_LPC1, "Intel Patsburg watchdog timer",	10, 2 },
+	{ DEVICEID_PATSBURG_LPC2, "Intel Patsburg watchdog timer",	10, 2 },
+	{ DEVICEID_PPT0,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT1,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT2,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT3,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT4,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT5,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT6,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT7,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT8,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT9,     "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT10,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT11,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT12,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT13,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT14,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT15,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT16,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT17,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT18,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT19,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT20,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT21,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT22,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT23,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT24,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT25,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT26,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT27,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT28,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT29,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT30,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_PPT31,    "Intel Panther Point watchdog timer",	10, 2 },
+	{ DEVICEID_LPT0,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT1,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT2,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT3,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT4,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT5,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT6,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT7,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT8,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT9,     "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT10,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT11,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT12,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT13,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT14,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT15,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT16,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT17,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT18,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT19,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT20,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT21,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT22,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT23,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT24,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT25,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT26,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT27,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT28,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT29,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT30,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_LPT31,    "Intel Lynx Point watchdog timer",		10, 2 },
+	{ DEVICEID_WCPT1,    "Intel Wildcat Point watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT2,    "Intel Wildcat Point watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT3,    "Intel Wildcat Point watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT4,    "Intel Wildcat Point watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT6,    "Intel Wildcat Point watchdog timer",	10, 2 },
+	{ DEVICEID_WBG0,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG1,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG2,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG3,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG4,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG5,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG6,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG7,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG8,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG9,     "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG10,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG11,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG12,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG13,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG14,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG15,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG16,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG17,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG18,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG19,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG20,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG21,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG22,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG23,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG24,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG25,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG26,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG27,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG28,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG29,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG30,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_WBG31,    "Intel Wellsburg watchdog timer",		10, 2 },
+	{ DEVICEID_LPT_LP0,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP1,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP2,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP3,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP4,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP5,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP6,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_LPT_LP7,  "Intel Lynx Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP1, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP2, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP3, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP5, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP6, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP7, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_WCPT_LP9, "Intel Wildcat Point-LP watchdog timer",	10, 2 },
+	{ DEVICEID_DH89XXCC_LPC,  "Intel DH89xxCC watchdog timer",	10, 2 },
+	{ DEVICEID_COLETOCRK_LPC, "Intel Coleto Creek watchdog timer",  10, 2 },
+	{ DEVICEID_AVN0,     "Intel Avoton/Rangeley SoC watchdog timer",10, 3 },
+	{ DEVICEID_AVN1,     "Intel Avoton/Rangeley SoC watchdog timer",10, 3 },
+	{ DEVICEID_AVN2,     "Intel Avoton/Rangeley SoC watchdog timer",10, 3 },
+	{ DEVICEID_AVN3,     "Intel Avoton/Rangeley SoC watchdog timer",10, 3 },
+	{ DEVICEID_BAYTRAIL, "Intel Bay Trail SoC watchdog timer",	10, 3 },
+	{ DEVICEID_BRASWELL, "Intel Braswell SoC watchdog timer",	10, 3 },
+	{ 0, NULL, 0, 0 },
 };
 
 static devclass_t ichwd_devclass;
@@ -241,7 +297,7 @@ static devclass_t ichwd_devclass;
 	bus_read_4((sc)->tco_res, (off))
 #define ichwd_read_smi_4(sc, off) \
 	bus_read_4((sc)->smi_res, (off))
-#define ichwd_read_gcs_4(sc, off) \
+#define ichwd_read_gcs_pmc_4(sc, off) \
 	bus_read_4((sc)->gcs_res, (off))
 
 #define ichwd_write_tco_1(sc, off, val) \
@@ -252,7 +308,7 @@ static devclass_t ichwd_devclass;
 	bus_write_4((sc)->tco_res, (off), (val))
 #define ichwd_write_smi_4(sc, off, val) \
 	bus_write_4((sc)->smi_res, (off), (val))
-#define ichwd_write_gcs_4(sc, off, val) \
+#define ichwd_write_gcs_pmc_4(sc, off, val) \
 	bus_write_4((sc)->gcs_res, (off), (val))
 
 #define ichwd_verbose_printf(dev, ...) \
@@ -352,7 +408,7 @@ ichwd_tmr_disable(struct ichwd_softc *sc)
 static __inline void
 ichwd_tmr_reload(struct ichwd_softc *sc)
 {
-	if (sc->ich_version <= 5)
+	if (sc->tco_version == 1)
 		ichwd_write_tco_1(sc, TCO_RLD, 1);
 	else
 		ichwd_write_tco_2(sc, TCO_RLD, 1);
@@ -369,7 +425,7 @@ ichwd_tmr_set(struct ichwd_softc *sc, unsigned int timeout)
 	if (timeout < TCO_RLD_TMR_MIN)
 		timeout = TCO_RLD_TMR_MIN;
 
-	if (sc->ich_version <= 5) {
+	if (sc->tco_version == 1) {
 		uint8_t tmr_val8 = ichwd_read_tco_1(sc, TCO_TMR1);
 
 		tmr_val8 &= (~TCO_RLD1_TMR_MAX & 0xff);
@@ -399,20 +455,40 @@ ichwd_clear_noreboot(struct ichwd_softc *sc)
 	int rc = 0;
 
 	/* try to clear the NO_REBOOT bit */
-	if (sc->ich_version <= 5) {
-		status = pci_read_config(sc->ich, ICH_GEN_STA, 1);
-		status &= ~ICH_GEN_STA_NO_REBOOT;
-		pci_write_config(sc->ich, ICH_GEN_STA, status, 1);
-		status = pci_read_config(sc->ich, ICH_GEN_STA, 1);
-		if (status & ICH_GEN_STA_NO_REBOOT)
-			rc = EIO;
-	} else {
-		status = ichwd_read_gcs_4(sc, 0);
-		status &= ~ICH_GCS_NO_REBOOT;
-		ichwd_write_gcs_4(sc, 0, status);
-		status = ichwd_read_gcs_4(sc, 0);
-		if (status & ICH_GCS_NO_REBOOT)
-			rc = EIO;
+	switch (sc->tco_version)
+	{
+		case 1:
+			status = pci_read_config(sc->ich, ICH_GEN_STA, 1);
+			status &= ~ICH_GEN_STA_NO_REBOOT;
+			pci_write_config(sc->ich, ICH_GEN_STA, status, 1);
+			status = pci_read_config(sc->ich, ICH_GEN_STA, 1);
+			if (status & ICH_GEN_STA_NO_REBOOT)
+				rc = EIO;
+			break;
+			
+		case 2:
+			status = ichwd_read_gcs_pmc_4(sc, 0);
+			status &= ~ICH_GCS_NO_REBOOT;
+			ichwd_write_gcs_pmc_4(sc, 0, status);
+			status = ichwd_read_gcs_pmc_4(sc, 0);
+			if (status & ICH_GCS_NO_REBOOT)
+				rc = EIO;
+			break;
+			
+		case 3:
+			status = ichwd_read_gcs_pmc_4(sc, 0);
+			status &= ~ICH_PMC_NO_REBOOT;
+			ichwd_write_gcs_pmc_4(sc, 0, status);
+			status = ichwd_read_gcs_pmc_4(sc, 0);
+			if (status & ICH_PMC_NO_REBOOT)
+				rc = EIO;
+			break;
+			
+		default:
+			ichwd_verbose_printf(sc->device,
+			    "Unknown TCO Version: %d, can't set NO_REBOOT.\n",
+			    sc->tco_version);
+			break;
 	}
 
 	if (rc)
@@ -434,7 +510,13 @@ ichwd_event(void *arg, unsigned int cmd, int *error)
 
 	/* convert from power-of-two-ns to WDT ticks */
 	cmd &= WD_INTERVAL;
-	timeout = ((uint64_t)1 << cmd) / ICHWD_TICK;
+	
+	if (sc->tco_version == 3) {
+		timeout = ((uint64_t)1 << cmd) / ICHWD_TCO_V3_TICK;
+	} else {
+		timeout = ((uint64_t)1 << cmd) / ICHWD_TICK;
+	}
+	
 	if (cmd) {
 		if (!sc->active)
 			ichwd_tmr_enable(sc);
@@ -463,7 +545,7 @@ ichwd_find_ich_lpc_bridge(struct ichwd_device **id_p)
 		return (NULL);
 
 	ichwd_verbose_printf(ich, "found ICH%d or equivalent chipset: %s\n",
-	    id->version, id->desc);
+	    id->ich_version, id->desc);
 
 	if (id_p)
 		*id_p = id;
@@ -481,7 +563,7 @@ ichwd_identify(driver_t *driver, device_t parent)
 	struct ichwd_device *id_p;
 	device_t ich = NULL;
 	device_t dev;
-	uint32_t rcba;
+	uint32_t base_address;
 	int rc;
 
 	ich = ichwd_find_ich_lpc_bridge(&id_p);
@@ -497,14 +579,40 @@ ichwd_identify(driver_t *driver, device_t parent)
 
 	device_set_desc_copy(dev, id_p->desc);
 
-	if (id_p->version >= 6) {
-		/* get RCBA (root complex base address) */
-		rcba = pci_read_config(ich, ICH_RCBA, 4);
-		rc = bus_set_resource(ich, SYS_RES_MEMORY, 0,
-		    (rcba & 0xffffc000) + ICH_GCS_OFFSET, ICH_GCS_SIZE);
-		if (rc)
+	switch (id_p->tco_version)
+	{
+		case 1:
+			break;
+			
+		case 2:
+			/* get RCBA (root complex base address) */
+			base_address = pci_read_config(ich, ICH_RCBA, 4);
+			rc = bus_set_resource(ich, SYS_RES_MEMORY, 0,
+			    (base_address & 0xffffc000) + ICH_GCS_OFFSET,
+			    ICH_GCS_SIZE);
+			if (rc)
+				ichwd_verbose_printf(dev,
+				    "Can not set TCO v%d memory resource for RCBA\n",
+				    id_p->tco_version);
+			break;
+			
+		case 3:
+			/* get PBASE (Power Management Controller base address) */
+			base_address = pci_read_config(ich, ICH_PBASE, 4);
+			rc = bus_set_resource(ich, SYS_RES_MEMORY, 0,
+			    (base_address & 0xfffffe00) + ICH_PMC_OFFSET,
+			    ICH_PMC_SIZE);
+			if (rc)
+				ichwd_verbose_printf(dev,
+				    "Can not set TCO v%d memory resource for PBASE\n",
+				    id_p->tco_version);
+			break;
+		
+		default:
 			ichwd_verbose_printf(dev,
-			    "Can not set memory resource for RCBA\n");
+			    "Can not set unknown TCO v%d memory resource for unknown base address\n",
+			    id_p->tco_version);
+			break;
 	}
 }
 
@@ -535,7 +643,8 @@ ichwd_attach(device_t dev)
 		goto fail;
 	}
 	sc->ich = ich;
-	sc->ich_version = id_p->version;
+	sc->ich_version = id_p->ich_version;
+	sc->tco_version = id_p->tco_version;
 
 	/* get ACPI base address */
 	pmbase = pci_read_config(ich, ICH_PMBASE, 2) & ICH_PMBASE_MASK;
@@ -564,7 +673,7 @@ ichwd_attach(device_t dev)
 	}
 
 	sc->gcs_rid = 0;
-	if (sc->ich_version >= 6) {
+	if (sc->tco_version >= 2) {
 		sc->gcs_res = bus_alloc_resource_any(ich, SYS_RES_MEMORY,
 		    &sc->gcs_rid, RF_ACTIVE|RF_SHAREABLE);
 		if (sc->gcs_res == NULL) {
@@ -577,7 +686,7 @@ ichwd_attach(device_t dev)
 		goto fail;
 
 	ichwd_verbose_printf(dev, "%s (ICH%d or equivalent)\n",
-	    device_get_desc(dev), sc->ich_version);
+	    id_p->desc, sc->ich_version);
 
 	/*
 	 * Determine if we are coming up after a watchdog-induced reset.  Some


### PR DESCRIPTION
Add support TCO v3 and Intel Avoton/Rangeley, Bay Trail, Braswell SoC.
Add bunch of PCI IDs of Intel Wellsburg, Lynx Point-LP, Wildcat Point-LP chipsets for TCO v2.