### PR TITLE
fixed spelling typo in documentation for the zfsboot script

### DIFF
--- a/usr.sbin/bsdinstall/scripts/zfsboot
+++ b/usr.sbin/bsdinstall/scripts/zfsboot
@@ -55,7 +55,7 @@ f_include $BSDCFG_SHARE/variable.subr
 : ${ZFSBOOT_BEROOT_NAME:=ROOT}
 
 #
-# Default name for the primany boot environment
+# Default name for the primary boot environment
 #
 : ${ZFSBOOT_BOOTFS_NAME:=default}
 


### PR DESCRIPTION
This PR fixes a spelling typo in the zfsboot script located under bsdinstall.