### PR TITLE
Changed LIBADD curses

### DIFF
--- a/tools/tools/ath/athratestats/Makefile
+++ b/tools/tools/ath/athratestats/Makefile
@@ -7,7 +7,7 @@ PROG=	athratestats
 
 SRCS=	main.c opt_ah.h ah_osdep.h
 
-LIBADD+=	curses
++LIBADD=	curses
 
 CLEANFILES+=	opt_ah.h ah_osdep.h
 


### PR DESCRIPTION
changed LIBADD+= curses to +LIBADD= curses.
The original resulted in a buildworld error. The alteration seems to fix this.