### PR TITLE
Wakeup only one thread while events are available

### DIFF
--- a/sys/kern/kern_event.c
+++ b/sys/kern/kern_event.c
@@ -1881,7 +1881,7 @@ kqueue_wakeup(struct kqueue *kq)
 
 	if ((kq->kq_state & KQ_SLEEP) == KQ_SLEEP) {
 		kq->kq_state &= ~KQ_SLEEP;
-		wakeup(kq);
+		wakeup_one(kq);
 	}
 	if ((kq->kq_state & KQ_SEL) == KQ_SEL) {
 		selwakeuppri(&kq->kq_sel, PSOCK);


### PR DESCRIPTION
There is no reason to wakeup all threads while there are events available, as that would make same event to be consumed by multiple threads at the same time and result in errors.