### PR TITLE
Allow user to select the boot pool if more than one found on the boot device

### DIFF
--- a/sys/boot/i386/zfsboot/zfsboot.c
+++ b/sys/boot/i386/zfsboot/zfsboot.c
@@ -624,7 +624,7 @@ main(void)
     /*
      * The first discovered pool, if any, is the pool.
      */
-    spa = spa_get_primary();
+    spa = spa_get_ask_user();
     if (!spa) {
 	printf("%s: No ZFS pools located, can't boot\n", BOOTPROG);
 	for (;;)


### PR DESCRIPTION
Currently the first zfs pool is chosen as the boot pool.
There may be cases (I am one such case) when a single disk is used to boot multiple machines, each from a separate zfs pool. The user thus needs to be able to select which pool to boot from.