### PR TITLE
Refresh geom labels

### DIFF
--- a/sbin/geom/class/label/glabel.8
+++ b/sbin/geom/class/label/glabel.8
@@ -63,6 +63,9 @@
 .Nm
 .Cm load
 .Nm
+.Cm refresh
+.Ar dev ...
+.Nm
 .Cm unload
 .Sh DESCRIPTION
 The
@@ -186,6 +189,8 @@ Same as
 Clear metadata on the given devices.
 .It Cm dump
 Dump metadata stored on the given devices.
+.It Cm refresh
+Refresh metadata from the given devices.
 .It Cm list
 See
 .Xr geom 8 .


### PR DESCRIPTION
Hello,

This change solves the following bug :
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=162690
It adds a "refresh" option to glabel command which refreshes labels from devices.

Would be glad to have it merged with 10.3 and 11 !

Thank you very much 👍 

Best regards,

Ben