### PR TITLE
Enable single-tap-to-click for wsp touchpad driver

### DIFF
--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -87,6 +87,9 @@ static struct wsp_tuning {
 	int	pressure_untouch_threshold;
 	int	pressure_tap_threshold;
 	int	scr_hor_threshold;
+	int	enable_single_tap_clicks;
+	int	enable_double_tap_and_drag;
+	int	enable_geographical_buttons;
 }
 	wsp_tuning =
 {
@@ -96,6 +99,9 @@ static struct wsp_tuning {
 	.pressure_untouch_threshold = 10,
 	.pressure_tap_threshold = 120,
 	.scr_hor_threshold = 20,
+	.enable_single_tap_clicks = 1,
+	.enable_double_tap_and_drag = 1,
+	.enable_geographical_buttons = 0,
 };
 
 static void
@@ -107,6 +113,9 @@ wsp_runing_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_untouch_threshold, 1, 255);
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
+	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
+	WSP_CLAMP(ptun->enable_double_tap_and_drag, 0, 1);
+	WSP_CLAMP(ptun->enable_geographical_buttons, 0, 1);
 }
 
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scale_factor, CTLFLAG_RWTUN,
@@ -121,6 +130,12 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, pressure_tap_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.pressure_tap_threshold, 0, "tap pressure threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.scr_hor_threshold, 0, "horizontal scrolling threshold");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_clicks, CTLFLAG_RWTUN,
+    &wsp_tuning.enable_single_tap_clicks, 0, "enable single tap clicks");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_double_tap_and_drag, CTLFLAG_RWTUN,
+    &wsp_tuning.enable_double_tap_and_drag, 0, "enable double tap-and-drag to left-click and drag");
+SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_geographical_buttons, CTLFLAG_RWTUN,
+    &wsp_tuning.enable_geographical_buttons, 0, "enable left-middle-right clicks based on tap location instead of number of tap fingers");
 
 /*
  * Some tables, structures, definitions and constant values for the
@@ -966,7 +981,7 @@ wsp_intr_callback(struct usb_xfer *xfer, usb_error_t error)
 				 */
 				switch (sc->ntaps) {
 				case 1:
-					if (!(params->caps & HAS_INTEGRATED_BUTTON)) {
+					if (!(params->caps & HAS_INTEGRATED_BUTTON) || tun.enable_single_tap_clicks) {
 						wsp_add_to_queue(sc, 0, 0, 0, MOUSE_BUTTON1DOWN);
 						DPRINTFN(WSP_LLEVEL_INFO, "LEFT CLICK!\n");
 					}

--- a/sys/dev/usb/input/wsp.c
+++ b/sys/dev/usb/input/wsp.c
@@ -88,8 +88,6 @@ static struct wsp_tuning {
 	int	pressure_tap_threshold;
 	int	scr_hor_threshold;
 	int	enable_single_tap_clicks;
-	int	enable_double_tap_and_drag;
-	int	enable_geographical_buttons;
 }
 	wsp_tuning =
 {
@@ -100,8 +98,6 @@ static struct wsp_tuning {
 	.pressure_tap_threshold = 120,
 	.scr_hor_threshold = 20,
 	.enable_single_tap_clicks = 1,
-	.enable_double_tap_and_drag = 1,
-	.enable_geographical_buttons = 0,
 };
 
 static void
@@ -114,8 +110,6 @@ wsp_runing_rangecheck(struct wsp_tuning *ptun)
 	WSP_CLAMP(ptun->pressure_tap_threshold, 1, 255);
 	WSP_CLAMP(ptun->scr_hor_threshold, 1, 255);
 	WSP_CLAMP(ptun->enable_single_tap_clicks, 0, 1);
-	WSP_CLAMP(ptun->enable_double_tap_and_drag, 0, 1);
-	WSP_CLAMP(ptun->enable_geographical_buttons, 0, 1);
 }
 
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scale_factor, CTLFLAG_RWTUN,
@@ -132,10 +126,6 @@ SYSCTL_INT(_hw_usb_wsp, OID_AUTO, scr_hor_threshold, CTLFLAG_RWTUN,
     &wsp_tuning.scr_hor_threshold, 0, "horizontal scrolling threshold");
 SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_single_tap_clicks, CTLFLAG_RWTUN,
     &wsp_tuning.enable_single_tap_clicks, 0, "enable single tap clicks");
-SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_double_tap_and_drag, CTLFLAG_RWTUN,
-    &wsp_tuning.enable_double_tap_and_drag, 0, "enable double tap-and-drag to left-click and drag");
-SYSCTL_INT(_hw_usb_wsp, OID_AUTO, enable_geographical_buttons, CTLFLAG_RWTUN,
-    &wsp_tuning.enable_geographical_buttons, 0, "enable left-middle-right clicks based on tap location instead of number of tap fingers");
 
 /*
  * Some tables, structures, definitions and constant values for the


### PR DESCRIPTION
This pull request enables the wsp kernel module to process a single touchpad tap and interpret this as a left-click event.
It is enabled by default, but can be disabled with the newly introducedd hw.usb.wsp.enable_single_tap_clicks sysctl.