### PR TITLE
Update tws.h

### DIFF
--- a/sys/dev/tws/tws.h
+++ b/sys/dev/tws/tws.h
@@ -67,7 +67,7 @@ extern int tws_queue_depth;
 
 #define TWS_DRIVER_VERSION_STRING "10.80.00.005"
 #define TWS_MAX_NUM_UNITS             65 
-#define TWS_MAX_NUM_LUNS              16
+#define TWS_MAX_NUM_LUNS              255
 #define TWS_MAX_IRQS                  2
 #define TWS_SCSI_INITIATOR_ID         66
 #define TWS_MAX_IO_SIZE               0x20000 /* 128kB */


### PR DESCRIPTION
`#define TWS_MAX_NUM_LUNS`
defines the maximum number of LUN's on the device and to my knowledge it shouldn't be limited to only 16 LUN's. In my config it was provoking problems because not all the disks (volumes) were detected. I changed the value to 32 in my config and everything seems to work now. However, I think the value should be 255.

I am not aware of the reason why it was 16 in the first place.