### PR TITLE
Update tw_cl_share.h

### DIFF
--- a/sys/dev/twa/tw_cl_share.h
+++ b/sys/dev/twa/tw_cl_share.h
@@ -68,7 +68,7 @@
 #define TW_CL_MAX_NUM_UNITS		32	/* max # of units we support */
 #endif /* TW_OSL_ENCLOSURE_SUPPORT */
 
-#define TW_CL_MAX_NUM_LUNS		16	/* max # of LUN's we support */
+#define TW_CL_MAX_NUM_LUNS		255	/* max # of LUN's we support */
 #define TW_CL_MAX_IO_SIZE		0x20000	/* 128K */
 
 /*


### PR DESCRIPTION
TW_CL_MAX_NUM_LUNS should not be 16 but I presume 255. I have a 3ware controller with more than 16 volumes (LUN's) and otherwise all LUN's above the 16'th are not working.