### PR TITLE
Fix include/arpa/nameser_compat.h by adding T_DNAME definition.

### DIFF
--- a/include/arpa/nameser_compat.h
+++ b/include/arpa/nameser_compat.h
@@ -175,6 +175,7 @@ typedef struct {
 #define T_ATMA		ns_t_atma
 #define T_NAPTR		ns_t_naptr
 #define T_A6		ns_t_a6
+#define T_DNAME		ns_t_dname
 #define T_OPT		ns_t_opt
 #define	T_TSIG		ns_t_tsig
 #define	T_IXFR		ns_t_ixfr


### PR DESCRIPTION
T_DNAME is missing from include/arpa/nameser_compat.h.  Ran across this when adding DNAME support to apache trafficserver, FreeBSD builds failed and had to add a workaround.