### PR TITLE
Ignore MSR_EXTFEATURES

### DIFF
--- a/usr.sbin/bhyve/xmsr.c
+++ b/usr.sbin/bhyve/xmsr.c
@@ -185,6 +185,10 @@ emulate_rdmsr(struct vmctx *ctx, int vcpu, uint32_t num, uint64_t *val)
 			*val = 0;
 			break;
 
+		case MSR_EXTFEATURES:
+			*val = 0;
+			break;
+
 		/*
 		 * OpenBSD guests test bit 0 of this MSR to detect if the
 		 * workaround for erratum 721 is already applied.


### PR DESCRIPTION
Ignore MSR_EXTFEATURES.
Not working FreeBSD11 on BHyVe on AMD FX Series.
https://forums.freebsd.org/threads/59649/