### PR TITLE
Fix bug 218512.

### DIFF
--- a/sbin/geom/class/eli/geli.8
+++ b/sbin/geom/class/eli/geli.8
@@ -303,7 +303,11 @@ Number of iterations to use with PKCS#5v2 when processing User Key
 passphrase component.
 If this option is not specified,
 .Nm
-will find the number of iterations which is equal to 2 seconds of crypto work.
+will use the number of iterations that has been previously set in the
+.Nm
+metadata.
+If that has not been set, it will find the number of iterations
+which is equal to 2 seconds of crypto work.
 If 0 is given, PKCS#5v2 will not be used.
 PKCS#5v2 processing is performed once, after all parts of the passphrase
 component have been read.

--- a/sys/boot/geli/geliboot.c
+++ b/sys/boot/geli/geliboot.c
@@ -188,7 +188,7 @@ geli_taste(int read_func(void *vdev, void *priv, off_t off, void *buf,
 		/* Swap device, skip it. */
 		return (1);
 	}
-	if (md.md_iterations < 0) {
+	if (md.md_passphrases == 0) {
 		/* XXX TODO: Support loading key files. */
 		/* Disk does not have a passphrase, skip it. */
 		return (1);
@@ -246,7 +246,7 @@ geli_attach(struct dsk *dskp, const char *passphrase, const u_char *mkeyp)
 		/*
 		 * Prepare Derived-Key from the user passphrase.
 		 */
-		if (geli_e->md.md_iterations < 0) {
+		if (geli_e->md.md_passphrases == 0) {
 			/* XXX TODO: Support loading key files. */
 			return (1);
 		} else if (geli_e->md.md_iterations == 0) {

--- a/sys/geom/eli/g_eli.c
+++ b/sys/geom/eli/g_eli.c
@@ -1056,7 +1056,7 @@ g_eli_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
 		G_ELI_DEBUG(0, "No valid keys on %s.", pp->name);
 		return (NULL);
 	}
-	if (md.md_iterations == -1) {
+	if (md.md_passphrases == 0) {
 		/* If there is no passphrase, we try only once. */
 		tries = 1;
 	} else {
@@ -1088,7 +1088,7 @@ g_eli_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
                  */
                 nkeyfiles = g_eli_keyfiles_load(&ctx, pp->name);
 
-                if (nkeyfiles == 0 && md.md_iterations == -1) {
+                if (nkeyfiles == 0 && md.md_passphrases == 0) {
                         /*
                          * No key files and no passphrase, something is
                          * definitely wrong here.
@@ -1103,7 +1103,7 @@ g_eli_taste(struct g_class *mp, struct g_provider *pp, int flags __unused)
                 }
 
                 /* Ask for the passphrase if defined. */
-                if (md.md_iterations >= 0) {
+                if (md.md_passphrases != 0) {
                         /* Try first with cached passphrase. */
                         if (i == 0) {
                                 if (!g_eli_boot_passcache)

--- a/tests/sys/geom/class/eli/setkey_test.sh
+++ b/tests/sys/geom/class/eli/setkey_test.sh
@@ -11,9 +11,16 @@ keyfile2=`mktemp $base.XXXXXX` || exit 1
 keyfile3=`mktemp $base.XXXXXX` || exit 1
 keyfile4=`mktemp $base.XXXXXX` || exit 1
 keyfile5=`mktemp $base.XXXXXX` || exit 1
+passphrase1=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1) || exit 1
+passfile1=`mktemp $base.XXXXXX` || exit 1
+passphrase2=$(cat /dev/random | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1) || exit 1
+passfile2=`mktemp $base.XXXXXX` || exit 1
 mdconfig -a -t malloc -s `expr $sectors + 1` -u $no || exit 1
 
-echo "1..16"
+echo "1..42"
+
+echo $passphrase1 > $passfile1
+echo $passphrase2 > $passfile2
 
 dd if=/dev/random of=${rnd} bs=512 count=${sectors} >/dev/null 2>&1
 hash1=`dd if=${rnd} bs=512 count=${sectors} 2>/dev/null | md5`
@@ -27,11 +34,10 @@ geli init -B none -P -K $keyfile1 md${no}
 geli attach -p -k $keyfile1 md${no}
 
 dd if=${rnd} of=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null
-rm -f $rnd
 hash2=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
 
 # Change current key (0) for attached provider.
-geli setkey -P -K $keyfile2 md${no}
+geli setkey -P -K $keyfile2 md${no} >/dev/null
 if [ $? -eq 0 ]; then
 	echo "ok 1"
 else
@@ -57,7 +63,7 @@ fi
 hash3=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
 
 # Change key 1 for attached provider.
-geli setkey -n 1 -P -K $keyfile3 md${no}
+geli setkey -n 1 -P -K $keyfile3 md${no} >/dev/null 2>&1
 if [ $? -eq 0 ]; then
 	echo "ok 4"
 else
@@ -76,7 +82,7 @@ hash4=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
 geli detach md${no}
 
 # Change current (1) key for detached provider.
-geli setkey -p -k $keyfile3 -P -K $keyfile4 md${no}
+geli setkey -p -k $keyfile3 -P -K $keyfile4 md${no} >/dev/null
 if [ $? -eq 0 ]; then
 	echo "ok 6"
 else
@@ -102,7 +108,7 @@ hash5=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
 geli detach md${no}
 
 # Change key 0 for detached provider.
-geli setkey -n 0 -p -k $keyfile4 -P -K $keyfile5 md${no}
+geli setkey -n 0 -p -k $keyfile4 -P -K $keyfile5 md${no} >/dev/null
 if [ $? -eq 0 ]; then
 	echo "ok 9"
 else
@@ -125,32 +131,269 @@ else
 	echo "not ok 11"
 fi
 hash6=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
-geli detach md${no}
 
-if [ ${hash1} = ${hash2} ]; then
+# Set passphrase on key 1
+geli setkey -n 1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
 	echo "ok 12"
 else
 	echo "not ok 12"
 fi
-if [ ${hash1} = ${hash3} ]; then
+geli detach md${no}
+
+# Set passphrase on key 0 detached provider
+geli setkey -n 0 -p -k $keyfile5 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+if [ $? -eq 0 ]; then
 	echo "ok 13"
 else
 	echo "not ok 13"
 fi
-if [ ${hash1} = ${hash4} ]; then
+
+# Attach with key 0
+geli attach -j $passfile1 -k $keyfile1 md${no}
+if [ $? -eq 0 ]; then
 	echo "ok 14"
 else
 	echo "not ok 14"
 fi
-if [ ${hash1} = ${hash5} ]; then
+hash7=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
+geli detach md${no}
+
+# Init with key
+geli init -B none -P -K $keyfile1 md${no}
+if [ $? -eq 0 ]; then
 	echo "ok 15"
 else
 	echo "not ok 15"
 fi
-if [ ${hash1} = ${hash6} ]; then
+
+# Attach with key 0
+geli attach -p -k $keyfile1 md${no}
+if [ $? -eq 0 ]; then
 	echo "ok 16"
+	dd if=${rnd} of=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null
 else
 	echo "not ok 16"
 fi
 
-rm -f $keyfile1 $keyfile2 $keyfile3 $keyfile4 $keyfile5
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 17"
+else
+	echo "not ok 17"
+fi
+
+# Set key 1
+geli setkey -n 1 -P -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 18"
+else
+	echo "not ok 18"
+fi
+
+# Set passphrase on key 1
+geli setkey -n 1 -i 10 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 19"
+else
+	echo "not ok 19"
+fi
+
+# Set passphrase on key 1 with different iterations
+geli setkey -n 1 -i 20 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 20"
+else
+	echo "not ok 20"
+fi
+hash8=`dd if=/dev/md${no}.eli bs=512 count=${sectors} 2>/dev/null | md5`
+
+# Set passphrase on key 0 with different iterations
+geli setkey -n 0 -i 30 -J $passfile1 -K $keyfile1 md${no} 2>/dev/null
+if [ $? -ne 0 ]; then
+	echo "ok 21"
+else
+	echo "not ok 21"
+fi
+geli detach md${no}
+
+geli init -B none -J $passfile1 -K $keyfile1 md${no}
+geli attach -j $passfile1 -k $keyfile1 md${no}
+# Test that iterations is set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} != "-1" ] && [ ${iters} != "4294967295" ]; then
+	echo "ok 22"
+else
+	echo "not ok 22"
+fi
+
+# Set passphrase on key 0 with different iterations
+geli setkey -n 0 -i 0 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 23"
+else
+	echo "not ok 23"
+fi
+
+geli setkey -n 0 -P -K $keyfile1 md${no} >/dev/null
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 24"
+else
+	echo "not ok 24"
+fi
+
+geli setkey -n 0 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+geli detach md${no}
+
+# Set passphrase on key 0 with different iterations
+geli setkey -n 0 -i 0 -j $passfile1 -k $keyfile1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 25"
+else
+	echo "not ok 25"
+fi
+
+geli setkey -n 0 -j $passfile2 -k $keyfile2 -P -K $keyfile1 md${no} >/dev/null
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 26"
+else
+	echo "not ok 26"
+fi
+
+geli attach -p -k $keyfile1 md${no}
+geli setkey -n 0 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+geli setkey -n 1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+geli delkey -a md${no}
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 27"
+else
+	echo "not ok 27"
+fi
+
+geli setkey -n 0 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+geli setkey -n 1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+geli delkey -n 0 md${no}
+# Test that iterations is set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} != "-1" ] && [ ${iters} != "4294967295" ]; then
+	echo "ok 28"
+else
+	echo "not ok 28"
+fi
+
+geli delkey -n 1 -f md${no}
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 29"
+else
+	echo "not ok 29"
+fi
+
+geli setkey -n 0 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+geli setkey -n 1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+geli detach md${no}
+
+geli delkey -a md${no}
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 30"
+else
+	echo "not ok 30"
+fi
+
+geli init -B none -J $passfile1 -K $keyfile1 md${no}
+geli setkey -n 1 -j $passfile1 -k $keyfile1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+geli delkey -n 0 md${no}
+# Test that iterations is set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} != "-1" ] && [ ${iters} != "4294967295" ]; then
+	echo "ok 31"
+else
+	echo "not ok 31"
+fi
+
+geli delkey -n 1 -f md${no}
+# Test that iterations is not set
+iters=$(geli dump md${no} | awk -F": " '($1 == " iterations" || $1 == "iterations") { print $2 }')
+if [ ${iters} == "-1" ] || [ ${iters} == "4294967295" ]; then
+	echo "ok 32"
+else
+	echo "not ok 32"
+fi
+
+geli init -B none -P -K $keyfile1 md${no}
+geli attach -p -k $keyfile1 md${no}
+
+# Set passphrase on key 1 provider
+geli setkey -n 1 -i 10 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 33"
+else
+	echo "not ok 33"
+fi
+
+geli detach md${no}
+
+geli init -B none -P -K $keyfile1 md${no}
+
+# Set passphrase on key 1 detached provider
+geli setkey -n 1 -i 10 -p -k $keyfile1 -J $passfile2 -K $keyfile2 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 34"
+else
+	echo "not ok 34"
+fi
+
+# Set passphrase on key 1 with different iterations
+geli setkey -n 1 -i 20 -p -k $keyfile1 -J $passfile1 -K $keyfile1 md${no} >/dev/null
+if [ $? -eq 0 ]; then
+	echo "ok 35"
+else
+	echo "not ok 35"
+fi
+
+if [ ${hash1} = ${hash2} ]; then
+	echo "ok 36"
+else
+	echo "not ok 36"
+fi
+if [ ${hash1} = ${hash3} ]; then
+	echo "ok 37"
+else
+	echo "not ok 37"
+fi
+if [ ${hash1} = ${hash4} ]; then
+	echo "ok 38"
+else
+	echo "not ok 38"
+fi
+if [ ${hash1} = ${hash5} ]; then
+	echo "ok 39"
+else
+	echo "not ok 39"
+fi
+if [ ${hash1} = ${hash6} ]; then
+	echo "ok 40"
+else
+	echo "not ok 40"
+fi
+if [ ${hash1} = ${hash7} ]; then
+	echo "ok 41"
+else
+	echo "not ok 41"
+fi
+if [ ${hash1} = ${hash8} ]; then
+	echo "ok 42"
+else
+	echo "not ok 42"
+fi
+
+rm -f $rnd $keyfile1 $keyfile2 $keyfile3 $keyfile4 $keyfile5 $passfile1 $passfile2


### PR DESCRIPTION
Add test cases to reproduce all the problems (and then some)
noted in bug 218512.

Allow setting passphrases and changing iterations in all cases
except when two passphrases are set or being set. In that case,
disallow changing iterations.

Modify the behavior of setkey's '-i' to be deterministic. If a
user uses setkey and does not specify '-i', geli will find how
many iterations it can do in 2 seconds. It is possible for
separate invocations of setkey to come up with different
iterations, which could result in a setkey failure because
iterations is not allowed to be changed. This is fixed by
using the iterations value from the metadata if it has already
been set, and then falling back to the calculation if no
iterations have been set in the metadata.

Update the geli man page to reflect the above changed behavior.

Add the md_passphrases field to the metadata and increase the geli
version to v8. This allows geli to know for certain if a passphrase
is set on the provider. The current implementation uses
md_iterations for this, but that only means a passphrase has been
set at some point in the past. The metadata will automatically be
updated from v7 to v8 on the first metadata disk write.

Adding md_passphrases has a side effect of aligning the remaining
metadata fields to 4 bytes, which should be better than the odd
byte alignment they currently have.

Use the md_passphrases field to determine if a passphrase is set on
a provider.

Use the md_passphrases field to determine if no passphrases are
remaining on a provider and the iterations field in the metadata
can be cleared.

Fix geli dump to output iterations correctly. Add md_passphrases
to dump.