### PR TITLE
Implement Bug 218679

### DIFF
--- a/sbin/geom/class/eli/geli.8
+++ b/sbin/geom/class/eli/geli.8
@@ -135,6 +135,12 @@ utility:
 .Fl s Ar oldsize
 .Ar prov
 .Nm
+.Cm verify
+.Op Fl pv
+.Op Fl j Ar passfile
+.Op Fl k Ar keyfile
+.Ar prov
+.Nm
 .Cm version
 .Op Ar prov ...
 .Nm
@@ -696,6 +702,34 @@ Additional options include:
 .Bl -tag -width ".Fl s Ar oldsize"
 .It Fl s Ar oldsize
 The size of the provider before it was resized.
+.El
+.It Cm verify
+Verify the given passphrase/keyfile can be decrypt the Master Key on the
+given provider.
+.Pp
+Additional options include:
+.Bl -tag -width ".Fl j Ar passfile"
+.It Fl j Ar passfile
+Specifies a file which contains the passphrase component of the User Key
+(or part of it).
+For more information see the description of the
+.Fl J
+option for the
+.Cm init
+subcommand.
+.It Fl k Ar keyfile
+Specifies a file which contains the keyfile component of the User Key
+(or part of it).
+For more information see the description of the
+.Fl K
+option for the
+.Cm init
+subcommand.
+.It Fl p
+Do not use a passphrase as a component of the User Key.
+Cannot be combined with the
+.Fl j
+option.
 .El
 .It Cm version
 If no arguments are given, the

--- a/sbin/geom/class/eli/geom_eli.c
+++ b/sbin/geom/class/eli/geom_eli.c
@@ -1754,8 +1754,10 @@ eli_verify(struct gctl_req *req)
 	}
 	prov = gctl_get_ascii(req, "arg0");
 
-	if (eli_metadata_read(req, prov, &md) == -1)
+	if (eli_metadata_read(req, prov, &md) == -1) {
+		gctl_error(req, "Could not get metadata from %s.", prov);
 		return;
+	}
 
 	if (md.md_keys == 0) {
 		gctl_error(req, "No valid keys on %s.", prov);
@@ -1765,6 +1767,7 @@ eli_verify(struct gctl_req *req)
 
 	/* Generate key for Master Key decryption. */
 	if (eli_genkey(req, &md, key, false) == NULL) {
+		gctl_error(req, "Could not get generate key for %s.", prov);
 		bzero(key, sizeof(key));
 		bzero(&md, sizeof(md));
 		return;


### PR DESCRIPTION
Add a 'verify' command to geli. This allows a user to verify a
key and/or passphrase without having to call commands that will
modify the system (such as attach or setkey).

Update geli man page to add new command.