### PR TITLE
Add missing argument for H_SET operation of the history function.

### DIFF
--- a/lib/libedit/editline.3
+++ b/lib/libedit/editline.3
@@ -767,7 +767,7 @@ Return the previous element in the history.
 Return the next element in the history.
 .It Dv H_CURR
 Return the current element in the history.
-.It Dv H_SET
+.It Dv H_SET , Fa "int position"
 Set the cursor to point to the requested element.
 .It Dv H_ADD , Fa "const char *str"
 Append


### PR DESCRIPTION
The H_SET operation of the history() function takes an int argument which is the
position of the item to which the cursor should be moved to.