### PR TITLE
Uniformize KASSERT use in PI mutex functions

### DIFF
--- a/sys/kern/kern_umtx.c
+++ b/sys/kern/kern_umtx.c
@@ -1579,8 +1579,7 @@ umtx_pi_setowner(struct umtx_pi *pi, struct thread *owner)
 
 	uq_owner = owner->td_umtxq;
 	mtx_assert(&umtx_lock, MA_OWNED);
-	if (pi->pi_owner != NULL)
-		panic("pi_owner != NULL");
+	KASSERT(pi->pi_owner == NULL, ("pi_owner != NULL"));
 	pi->pi_owner = owner;
 	TAILQ_INSERT_TAIL(&uq_owner->uq_pi_contested, pi, pi_link);
 }


### PR DESCRIPTION
Only one function in kern_umtx.c directly calls panic().
Shouldn't it use the KASSERT macro instead, like any other function in this file?