### PR TITLE
remove a superfluous <space> character before '^\'

### DIFF
--- a/contrib/nvi/vi/v_cmd.c
+++ b/contrib/nvi/vi/v_cmd.c
@@ -130,7 +130,7 @@ VIKEYS const vikeys [MAXVIKEY + 1] = {
 /* 034  ^\ */
 	{v_exmode,	0,
 	    "^\\",
-	    " ^\\ switch to ex mode"},
+	    "^\\ switch to ex mode"},
 /* 035  ^] */
 	{v_tagpush,	V_ABS|V_KEYW|VM_RCM_SET,
 	    "^]",


### PR DESCRIPTION
This fixes alignment in vi's 'viusage' command.

This has been fixed [upstream](http://repo.or.cz/nvi.git/commit/4703128e5fd17a020e111baefd1bcc96c3062de2) and in [OpenBSD](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/vi/vi/v_cmd.c.diff?r1=1.4&r2=1.5&sortby=date&f=h).