### PR TITLE
Change variable foff to type vm_ooffset_t.

### DIFF
--- a/sys/vm/vm_mmap.c
+++ b/sys/vm/vm_mmap.c
@@ -1196,7 +1196,7 @@ vm_mmap_vnode(struct thread *td, vm_size_t objsize,
 {
 	struct vattr va;
 	vm_object_t obj;
-	vm_offset_t foff;
+	vm_ooffset_t foff;
 	struct ucred *cred;
 	int error, flags, locktype;
 


### PR DESCRIPTION
In i386, vm_offset_t is 32-bit and vm_ooffset_t is 64-bit. foff should be 64-bit instead of 32-bit. All the places where foff appears are expecting a variable of type vm_ooffset_t instead of vm_offset_t.