### PR TITLE
Suggest changing to selection sort

### DIFF
--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -229,13 +229,11 @@ restart:
 		struct sysinit *save;
 
 		min = sipp;
-		for (xipp = sipp + 1; xipp < sysinit_end; xipp++) {
+		for (xipp = sipp + 1; xipp < sysinit_end; xipp++)
 			if ((*xipp)->subsystem < (*min)->subsystem ||
 			    ((*xipp)->subsystem == (*min)->subsystem &&
-			     (*xipp)->order < (*min)->order)) {
-			        min = xipp;
-			}
-		}
+			     (*xipp)->order < (*min)->order))
+				min = xipp;
 		save = *sipp;
 		*sipp = *min;
 		*min = save;

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -203,10 +203,7 @@ symbol_name(vm_offset_t va, db_strategy_t strategy)
 void
 mi_startup(void)
 {
-
 	struct sysinit **sipp;	/* system initialization*/
-	struct sysinit **xipp;	/* interior loop of sort*/
-	struct sysinit *save;	/* bubble*/
 
 #if defined(VERBOSE_SYSINIT)
 	int last;
@@ -223,19 +220,25 @@ mi_startup(void)
 
 restart:
 	/*
-	 * Perform a bubble sort of the system initialization objects by
+	 * Perform a selection sort of the system initialization objects by
 	 * their subsystem (primary key) and order (secondary key).
 	 */
-	for (sipp = sysinit; sipp < sysinit_end; sipp++) {
+	for (sipp = sysinit; sipp < sysinit_end-1; sipp++) {
+		register struct sysinit **xipp;	/* interior loop of sort*/
+		register struct sysinit **min;
+		register struct sysinit *save;
+
+		min = sipp;
 		for (xipp = sipp + 1; xipp < sysinit_end; xipp++) {
-			if ((*sipp)->subsystem < (*xipp)->subsystem ||
-			     ((*sipp)->subsystem == (*xipp)->subsystem &&
-			      (*sipp)->order <= (*xipp)->order))
-				continue;	/* skip*/
-			save = *sipp;
-			*sipp = *xipp;
-			*xipp = save;
+			if ((*xipp)->subsystem < (*min)->subsystem ||
+			    ((*xipp)->subsystem == (*min)->subsystem &&
+			     (*xipp)->order < (*min)->order)) {
+			        min = xipp;
+			}
 		}
+		save = *sipp;
+		*sipp = *min;
+		*min = save;
 	}
 
 #if defined(VERBOSE_SYSINIT)

--- a/sys/kern/init_main.c
+++ b/sys/kern/init_main.c
@@ -223,10 +223,10 @@ restart:
 	 * Perform a selection sort of the system initialization objects by
 	 * their subsystem (primary key) and order (secondary key).
 	 */
-	for (sipp = sysinit; sipp < sysinit_end-1; sipp++) {
-		register struct sysinit **xipp;	/* interior loop of sort*/
-		register struct sysinit **min;
-		register struct sysinit *save;
+	for (sipp = sysinit; sipp < sysinit_end - 1; sipp++) {
+		struct sysinit **xipp;	/* interior loop of sort*/
+		struct sysinit **min;
+		struct sysinit *save;
 
 		min = sipp;
 		for (xipp = sipp + 1; xipp < sysinit_end; xipp++) {


### PR DESCRIPTION
I have tested both bubble sort and selection sort on my test machine. Selection sort runs faster. The test method is as follows:
1. Read the tsc before and after the for loop
2. Calculate the tsc difference
3. Reboot the system to get more tsc difference samples of the for loop.

Here is my test result. I reboot the system 4 times for each sorting algorithm and the average of tsc difference are
bubble sort: 7,220,292
selection sort: 3.976,695

Selection sort takes only 55% of the time compared to bubble sort.