### PR TITLE
Remove archaic, difficult to maintain, unlikely to be used code from …

### DIFF
--- a/crypto/openssl/crypto/cryptlib.c
+++ b/crypto/openssl/crypto/cryptlib.c
@@ -117,10 +117,6 @@
 #include "cryptlib.h"
 #include <openssl/safestack.h>
 
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN16)
-static double SSLeay_MSVC5_hack = 0.0; /* and for VC1.5 */
-#endif
-
 DECLARE_STACK_OF(CRYPTO_dynlock)
 
 /* real #defines in crypto.h, keep these upto date */
@@ -206,15 +202,6 @@ int CRYPTO_get_new_lockid(char *name)
 {
     char *str;
     int i;
-
-#if defined(OPENSSL_SYS_WIN32) || defined(OPENSSL_SYS_WIN16)
-    /*
-     * A hack to make Visual C++ 5.0 work correctly when linking as a DLL
-     * using /MT. Without this, the application cannot use any floating point
-     * printf's. It also seems to be needed for Visual C 1.5 (win16)
-     */
-    SSLeay_MSVC5_hack = (double)name[0] * (double)name[1];
-#endif
 
     if ((app_locks == NULL)
         && ((app_locks = sk_OPENSSL_STRING_new_null()) == NULL)) {


### PR DESCRIPTION
…OpenSSL

"dead meat belongs in frying pans or ovens" -- xmj, sorry, but I'm sure you'll agree with this.

For a start, it's extremely unlikely that anyone is going to try to compile FreeBSD with Microsoft Visual C++ 5.0.

Secondly, there's no logical cause and effect here. The function the code tries to communicate with (defined here: <https://msdn.microsoft.com/en-us/library/windows/desktop/ms647550(v=vs.85).aspx>) can't see this variable. If it can, it can only do so by inspecting some hard-coded value from "the stack" or something "magical" (A.K.A. undefined behaviour). That makes this a nightmare to maintain, as introducing new variables before it will cause it to break, for a compiler nobody even uses anymore!

Finally, throughout my research (yes, I did do research, contrary to the assumption otherwise), I found no evidence that this "hack" would resolve the problem. I crafted searches with different combinations of keywords such as "MSVC++ 5.0", "printf", "double", "MT" ... and even though I found evidence that the functions (on Windows, which is unimportant) indeed don't support floating points, I could find no other reference to this "hack" or "work-around" (those two are keywords, too, in case you'd like to try to verify my research).