### PR TITLE
Update crontab $PATH

### DIFF
--- a/etc/crontab
+++ b/etc/crontab
@@ -3,7 +3,7 @@
 # $FreeBSD$
 #
 SHELL=/bin/sh
-PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 #
 #minute	hour	mday	month	wday	who	command
 #


### PR DESCRIPTION
Hi,

This PR sets `$PATH` in `/etc/crontab` like it is set by the `cron(8)` daemon, for consistency.
It then solves https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=213742.

Thank you 👍 

Ben