### PR TITLE
Update kern_exec.c

### DIFF
--- a/sys/kern/kern_exec.c
+++ b/sys/kern/kern_exec.c
@@ -1512,6 +1512,7 @@ exec_copyout_strings(struct image_params *imgp)
 	 */
 	if (execpath_len != 0) {
 		destp -= execpath_len;
+		destp = rounddown2(destp, sizeof(void *));
 		imgp->execpathp = destp;
 		copyout(imgp->execpath, (void *)destp, execpath_len);
 	}


### PR DESCRIPTION
Let 'destp' align on pointer boundary will make copyout run faster.