### PR TITLE
Add AMD X370 AHCI and XHCI PCI IDs

### DIFF
--- a/sys/dev/ahci/ahci_pci.c
+++ b/sys/dev/ahci/ahci_pci.c
@@ -69,7 +69,8 @@ static const struct {
 	/* Not sure SB8x0/SB9x0 needs this quirk. Be conservative though */
 	{0x43951002, 0x00, "AMD SB8x0/SB9x0",	AHCI_Q_ATI_PMP_BUG},
 	{0x43b61022, 0x00, "AMD X399",		0},
-	{0x43b71022, 0x00, "AMD 300 Series",	0},
+	{0x43b51022, 0x00, "AMD 300 Series",	0}, /* X370 */
+	{0x43b71022, 0x00, "AMD 300 Series",	0}, /* B350 */
 	{0x78001022, 0x00, "AMD Hudson-2",	0},
 	{0x78011022, 0x00, "AMD Hudson-2",	0},
 	{0x78021022, 0x00, "AMD Hudson-2",	0},

--- a/sys/dev/usb/controller/xhci_pci.c
+++ b/sys/dev/usb/controller/xhci_pci.c
@@ -101,7 +101,8 @@ xhci_pci_match(device_t self)
 		return ("AMD KERNCZ USB 3.0 controller");
 	case 0x43ba1022:
 		return ("AMD X399 USB 3.0 controller");
-	case 0x43bb1022:
+	case 0x43b91022: /* X370 */
+	case 0x43bb1022: /* B350 */
 		return ("AMD 300 Series USB 3.0 controller");
 	case 0x78141022:
 		return ("AMD FCH USB 3.0 controller");


### PR DESCRIPTION
Previously posted as https://reviews.freebsd.org/D15398 — no one answered, let's try here :)