### PR TITLE
Add thermal sensor dtb overlay for Allwinner H3

### DIFF
--- a/sys/dts/arm/overlays/sun8i-h3-ts.dtso
+++ b/sys/dts/arm/overlays/sun8i-h3-ts.dtso
@@ -1,0 +1,23 @@
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/clock/sun8i-h3-ccu.h>
+#include <dt-bindings/reset/sun8i-h3-ccu.h>
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+};
+
+&{/soc} {
+	rtp: rtp@1c25000 {
+		compatible = "allwinner,sun8i-h3-ts";
+		reg = <0x01c25000 0x400>;
+		interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
+		clocks = <&ccu CLK_BUS_THS>, <&ccu CLK_THS>;
+		clock-names = "ahb", "ths";
+		resets = <&ccu RST_BUS_THS>;
+		#thermal-sensor-cells = <0>;
+		status = "okay";
+	};
+};

--- a/sys/modules/dtb/allwinner/Makefile
+++ b/sys/modules/dtb/allwinner/Makefile
@@ -20,6 +20,7 @@ DTS=	\
 	sun8i-h3-orangepi-plus2e.dts
 
 DTSO=	sun8i-a83t-sid.dtso \
+	sun8i-h3-ts.dtso \
 	sun8i-h3-sid.dtso
 
 LINKS= \


### PR DESCRIPTION
Previously/related: https://reviews.freebsd.org/D13556 — `aw_sid` (required for calibration in `aw_thermal`)

`aw_thermal` was lost and not added as an overlay. With this overlay, it works again. Tested on Orange Pi PC.