### PR TITLE
Remove %%fs and %%gs in the counter add function

### DIFF
--- a/sys/amd64/include/counter.h
+++ b/sys/amd64/include/counter.h
@@ -83,10 +83,12 @@ counter_u64_zero_inline(counter_u64_t c)
 static inline void
 counter_u64_add(counter_u64_t c, int64_t inc)
 {
+	uint64_t *counter_addr;
 
-	__asm __volatile("addq\t%1,%%gs:(%0)"
+	counter_addr = zpcpu_get(c);
+	__asm __volatile("addq\t%1,(%0)"
 	    :
-	    : "r" ((char *)c - (char *)&__pcpu[0]), "ri" (inc)
+	    : "r" (counter_addr), "ri" (inc)
 	    : "memory", "cc");
 }
 

--- a/sys/i386/include/counter.h
+++ b/sys/i386/include/counter.h
@@ -161,12 +161,12 @@ counter_u64_zero_inline(counter_u64_t c)
 #define	counter_u64_add_protected(c, inc)	do {	\
 	uint64_t *counter_addr;				\
 							\
-	counter_addr = zpcpu_get(c);			\
+	counter_addr = zpcpu_get((c));			\
 	if ((cpu_feature & CPUID_CX8) == 0) {		\
 		CRITICAL_ASSERT(curthread);		\
 		*counter_addr += (inc);			\
 	} else						\
-		counter_64_inc_8b((counter_addr), (inc));	 \
+		counter_64_inc_8b(counter_addr, (inc));	\
 } while (0)
 
 static inline void

--- a/sys/i386/include/counter.h
+++ b/sys/i386/include/counter.h
@@ -66,7 +66,7 @@ counter_64_inc_8b(uint64_t *p, int64_t inc)
 	"adcl	4(%%edi),%%ecx\n\t"
 	"cmpxchg8b (%%esi)\n\t"
 	"jnz	1b"
-	: /* no output registers */
+	:
 	: "S" (p), "D" (&inc)
 	: "memory", "cc", "eax", "edx", "ebx", "ecx");
 }


### PR DESCRIPTION
%%fs (i386) and %%gs (amd64) is confusing in the counter addition function. Since we can get the absolute address of the counter by calling zpcpu_get function, I think it's better to use that function instead of using %%fs and %%gs.