### PR TITLE
Add an SPI (spigen) overlay for the Allwinner H3 SoC

### DIFF
--- a/sys/dts/arm/overlays/sun8i-h3-spi.dtso
+++ b/sys/dts/arm/overlays/sun8i-h3-spi.dtso
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "allwinner,sun8i-h3";
+};
+
+&spi0 {
+	status = "okay";
+	spigen0: spigen0 {
+		compatible = "freebsd,spigen";
+		reg = <0>;
+		spi-max-frequency = <500000>; /* Req'd property, override with spi(8) */
+		status = "okay";
+	};
+};
+
+&spi1 {
+	status = "okay";
+	spigen1: spigen1 {
+		compatible = "freebsd,spigen";
+		reg = <1>;
+		spi-max-frequency = <500000>; /* Req'd property, override with spi(8) */
+		status = "okay";
+	};
+};

--- a/sys/modules/dtb/allwinner/Makefile
+++ b/sys/modules/dtb/allwinner/Makefile
@@ -21,7 +21,8 @@ DTS=	\
 	sun8i-h3-orangepi-plus2e.dts
 
 DTSO=	sun8i-a83t-sid.dtso \
-	sun8i-h3-sid.dtso
+	sun8i-h3-sid.dtso \
+	sun8i-h3-spi.dtso
 
 LINKS= \
 	${DTBDIR}/sun4i-a10-cubieboard.dtb ${DTBDIR}/cubieboard.dtb \


### PR DESCRIPTION
Tested on: Orange Pi PC + Winbond W25Q32.V

(with [flashrom](https://github.com/flashrom/flashrom/pull/53), even)

Possibly there should be more than one `spigen` per `spi`? The Raspberry Pi stuff has three…