### PR TITLE
fix hn_set_hlen so it doesn't return NULL on UDPv6

### DIFF
--- a/sys/dev/hyperv/netvsc/if_hn.c
+++ b/sys/dev/hyperv/netvsc/if_hn.c
@@ -861,7 +861,7 @@ hn_set_hlen(struct mbuf *m_head)
 
 		PULLUP_HDR(m_head, ehlen + sizeof(*ip6));
 		ip6 = mtodo(m_head, ehlen);
-		if (ip6->ip6_nxt != IPPROTO_TCP) {
+		if ((ip6->ip6_nxt != IPPROTO_TCP) & (ip6->ip6_nxt != IPPROTO_UDP)) {
 			m_freem(m_head);
 			return (NULL);
 		}


### PR DESCRIPTION
As it was, this function discards UDPv6 packets which breaks IPv6 on Hyper-V servers.