### PR TITLE
Document that ENOTCAPABLE can be returned via sendfile(2)

### DIFF
--- a/lib/libc/sys/sendfile.2
+++ b/lib/libc/sys/sendfile.2
@@ -25,7 +25,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd November 17, 2016
+.Dd October 12, 2018
 .Dt SENDFILE 2
 .Os
 .Sh NAME
@@ -336,6 +336,12 @@ is negative.
 .It Bq Er EIO
 An error occurred while reading from
 .Fa fd .
+.It Bq Er ENOTCAPABLE
+The
+.Fa fd
+or the
+.Fa s
+argument has insufficient rights.
 .It Bq Er ENOBUFS
 The system was unable to allocate an internal buffer.
 .It Bq Er ENOTCONN


### PR DESCRIPTION
As of this writing, `fd` must have `CAP_PREAD` rights and `s` must have
`CAP_SEND` rights in order for the sendfile(2) call to be successful.

Bug:	232207
Submitted by:	Enji Cooper <yaneurabeya@gmail.com>