### PR TITLE
Clean up the tests/sys/audit integration work

### DIFF
--- a/tests/sys/Makefile
+++ b/tests/sys/Makefile
@@ -6,7 +6,7 @@ TESTSDIR=		${TESTSBASE}/sys
 
 TESTS_SUBDIRS+=		acl
 TESTS_SUBDIRS+=		aio
-TESTS_SUBDIRS+=		audit
+TESTS_SUBDIRS+=		${_audit}
 TESTS_SUBDIRS+=		auditpipe
 TESTS_SUBDIRS+=		capsicum
 TESTS_SUBDIRS+=		${_cddl}
@@ -26,6 +26,10 @@ TESTS_SUBDIRS+=		posixshm
 TESTS_SUBDIRS+=		sys
 TESTS_SUBDIRS+=		vfs
 TESTS_SUBDIRS+=		vm
+
+.if ${MK_AUDIT} != "no"
+_audit=	audit
+.endif
 
 .if ${MK_CDDL} != "no"
 _cddl=	cddl

--- a/tests/sys/audit/Makefile
+++ b/tests/sys/audit/Makefile
@@ -49,6 +49,7 @@ SRCS.miscellaneous+=		utils.c
 TEST_METADATA+= timeout="30"
 TEST_METADATA+= required_user="root"
 TEST_METADATA+= is_exclusive="true"
+TEST_METADATA+=	required_files="/etc/rc.d/auditd"
 
 WARNS?=	6
 

--- a/tests/sys/audit/administrative.c
+++ b/tests/sys/audit/administrative.c
@@ -377,6 +377,8 @@ ATF_TC_HEAD(acct_success, tc)
 {
 	atf_tc_set_md_var(tc, "descr", "Tests the audit of a successful "
 					"acct(2) call");
+	atf_tc_set_md_var(tc, "require.files",
+	    "/etc/rc.d/accounting /etc/rc.d/auditd");
 }
 
 ATF_TC_BODY(acct_success, tc)

--- a/tools/build/mk/OptionalObsoleteFiles.inc
+++ b/tools/build/mk/OptionalObsoleteFiles.inc
@@ -160,6 +160,22 @@ OLD_FILES+=usr/share/man/man5/auditdistd.conf.5.gz
 OLD_FILES+=usr/share/man/man8/audit.8.gz
 OLD_FILES+=usr/share/man/man8/auditd.8.gz
 OLD_FILES+=usr/share/man/man8/auditdistd.8.gz
+OLD_FILES+=usr/tests/sys/audit/process-control
+OLD_FILES+=usr/tests/sys/audit/open
+OLD_FILES+=usr/tests/sys/audit/network
+OLD_FILES+=usr/tests/sys/audit/miscellaneous
+OLD_FILES+=usr/tests/sys/audit/Kyuafile
+OLD_FILES+=usr/tests/sys/audit/ioctl
+OLD_FILES+=usr/tests/sys/audit/inter-process
+OLD_FILES+=usr/tests/sys/audit/file-write
+OLD_FILES+=usr/tests/sys/audit/file-read
+OLD_FILES+=usr/tests/sys/audit/file-delete
+OLD_FILES+=usr/tests/sys/audit/file-create
+OLD_FILES+=usr/tests/sys/audit/file-close
+OLD_FILES+=usr/tests/sys/audit/file-attribute-modify
+OLD_FILES+=usr/tests/sys/audit/file-attribute-access
+OLD_FILES+=usr/tests/sys/audit/administrative
+OLD_DIRS+=usr/tests/sys/audit
 .endif
 
 .if ${MK_AUTHPF} == no


### PR DESCRIPTION
There were some issues with the integration that became apparent on my system as I have MK_ACCT set to no in src.conf(5).

This pull request fixes the integration work, in addition to the fact that similar issues existed with MK_AUDIT == no, but in a more fundamental manner.

Submitted by: ngie