### PR TITLE
Unbreak ATF-based geli/gmirror testcases if their geom classes cannot be loaded

### DIFF
--- a/tests/sys/geom/class/eli/attach_test.sh
+++ b/tests/sys/geom/class/eli/attach_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case attach_d cleanup
 attach_d_head()
 {
@@ -8,7 +10,7 @@ attach_d_head()
 }
 attach_d_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -35,7 +37,6 @@ attach_d_body()
 }
 attach_d_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -47,7 +48,7 @@ attach_r_head()
 }
 attach_r_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -64,7 +65,6 @@ attach_r_body()
 }
 attach_r_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -76,7 +76,7 @@ nokey_head()
 }
 nokey_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -88,7 +88,6 @@ nokey_body()
 }
 nokey_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/conf.sh
+++ b/tests/sys/geom/class/eli/conf.sh
@@ -82,7 +82,6 @@ for_each_geli_config_nointegrity() {
 	done
 }
 
-
 geli_test_cleanup()
 {
 	if [ -f "$TEST_MDS_FILE" ]; then
@@ -95,4 +94,10 @@ geli_test_cleanup()
 	true
 }
 
+geli_test_setup()
+{
+	geom_atf_test_setup
+}
+
+ATF_TEST=true
 . `dirname $0`/../geom_subr.sh

--- a/tests/sys/geom/class/eli/configure_test.sh
+++ b/tests/sys/geom/class/eli/configure_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case configure_b_B cleanup
 configure_b_B_head()
 {
@@ -8,7 +10,7 @@ configure_b_B_head()
 }
 configure_b_B_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -49,7 +51,6 @@ configure_b_B_body()
 }
 configure_b_B_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/delkey_test.sh
+++ b/tests/sys/geom/class/eli/delkey_test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case delkey cleanup
 delkey_head()
 {
@@ -9,7 +11,7 @@ delkey_head()
 }
 delkey_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -76,7 +78,6 @@ delkey_body()
 }
 delkey_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -88,7 +89,7 @@ delkey_readonly_head()
 }
 delkey_readonly_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -103,7 +104,6 @@ delkey_readonly_body()
 }
 delkey_readonly_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/detach_test.sh
+++ b/tests/sys/geom/class/eli/detach_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case detach_l cleanup
 detach_l_head()
 {
@@ -8,7 +10,7 @@ detach_l_head()
 }
 detach_l_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -36,7 +38,6 @@ detach_l_body()
 }
 detach_l_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/init_test.sh
+++ b/tests/sys/geom/class/eli/init_test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 init_test()
 {
 	cipher=$1
@@ -39,7 +41,7 @@ init_head()
 }
 init_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=32
 
@@ -50,7 +52,6 @@ init_body()
 }
 init_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -62,7 +63,7 @@ init_B_head()
 }
 init_B_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 
@@ -104,7 +105,6 @@ init_B_body()
 }
 init_B_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -116,7 +116,7 @@ init_J_head()
 }
 init_J_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -223,7 +223,6 @@ init_J_body()
 }
 init_J_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -260,7 +259,7 @@ init_a_head()
 }
 init_a_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 
@@ -272,7 +271,6 @@ init_a_body()
 }
 init_a_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -304,7 +302,7 @@ init_alias_head()
 }
 init_alias_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	md=$(attach_md -t malloc -s 1024k)
 	atf_check dd if=/dev/random of=keyfile bs=512 count=16 status=none
@@ -330,7 +328,6 @@ init_alias_body()
 }
 init_alias_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -342,7 +339,7 @@ init_i_P_head()
 }
 init_i_P_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -354,7 +351,6 @@ init_i_P_body()
 }
 init_i_P_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -366,7 +362,7 @@ nokey_head()
 }
 nokey_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -376,7 +372,6 @@ nokey_body()
 }
 nokey_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/integrity_test.sh
+++ b/tests/sys/geom/class/eli/integrity_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 copy_test() {
 	cipher=$1
 	aalgo=$2
@@ -51,18 +53,17 @@ copy_head()
 }
 copy_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=2
 
 	atf_check dd if=/dev/random of=keyfile bs=512 count=16 status=none
 	dd if=/dev/random of=rnd bs=${MAX_SECSIZE} count=${sectors} status=none
-	
+
 	for_each_geli_config copy_test backing_file
 }
 copy_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -98,7 +99,7 @@ data_head()
 }
 data_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=2
 
@@ -108,7 +109,6 @@ data_body()
 }
 data_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -143,7 +143,7 @@ hmac_head()
 }
 hmac_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=2
 
@@ -153,7 +153,6 @@ hmac_body()
 }
 hmac_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/kill_test.sh
+++ b/tests/sys/geom/class/eli/kill_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case kill cleanup
 kill_head()
 {
@@ -8,7 +10,7 @@ kill_head()
 }
 kill_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -61,7 +63,6 @@ kill_body()
 }
 kill_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -73,7 +74,7 @@ kill_readonly_head()
 }
 kill_readonly_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -91,7 +92,6 @@ kill_readonly_body()
 }
 kill_readonly_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/onetime_test.sh
+++ b/tests/sys/geom/class/eli/onetime_test.sh
@@ -1,5 +1,7 @@
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 onetime_test()
 {
 	cipher=$1
@@ -35,7 +37,8 @@ onetime_head()
 }
 onetime_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
+
 	sectors=100
 
 	dd if=/dev/random of=rnd bs=${MAX_SECSIZE} count=${sectors} status=none
@@ -43,7 +46,6 @@ onetime_body()
 }
 onetime_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -78,7 +80,8 @@ onetime_a_head()
 }
 onetime_a_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
+
 	sectors=8
 
 	atf_check dd if=/dev/random of=rnd bs=$MAX_SECSIZE count=$sectors \
@@ -87,7 +90,6 @@ onetime_a_body()
 }
 onetime_a_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -99,7 +101,7 @@ onetime_d_head()
 }
 onetime_d_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s $sectors)
@@ -125,7 +127,6 @@ onetime_d_body()
 }
 onetime_d_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/eli/resize_test.sh
+++ b/tests/sys/geom/class/eli/resize_test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case resize cleanup
 resize_head()
 {
@@ -9,7 +11,8 @@ resize_head()
 }
 resize_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
+
 	BLK=512
 	BLKS_PER_MB=2048
 
@@ -67,8 +70,6 @@ resize_body()
 }
 resize_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
-
 	if [ -f "$TEST_MDS_FILE" ]; then
 		while read md; do
 			[ -c /dev/${md}a.eli ] && \

--- a/tests/sys/geom/class/eli/setkey_test.sh
+++ b/tests/sys/geom/class/eli/setkey_test.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # $FreeBSD$
 
+. $(atf_get_srcdir)/conf.sh
+
 atf_test_case setkey cleanup
 setkey_head()
 {
@@ -9,7 +11,7 @@ setkey_head()
 }
 setkey_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -88,7 +90,6 @@ setkey_body()
 }
 setkey_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -100,7 +101,7 @@ setkey_readonly_head()
 }
 setkey_readonly_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -114,7 +115,6 @@ setkey_readonly_body()
 }
 setkey_readonly_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 
@@ -126,7 +126,7 @@ nokey_head()
 }
 nokey_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geli_test_setup
 
 	sectors=100
 	md=$(attach_md -t malloc -s `expr $sectors + 1`)
@@ -152,7 +152,6 @@ nokey_body()
 }
 nokey_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
 	geli_test_cleanup
 }
 

--- a/tests/sys/geom/class/geom_subr.sh
+++ b/tests/sys/geom/class/geom_subr.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 # $FreeBSD$
 
+# NOTE: existence is sanity-checked in `geom_verify_temp_mds_file_existence(..)`
+TEST_MDS_FILE="$(mktemp test_mds.${0##*/}.XXXXXXXX)"
+
 devwait()
 {
 	while :; do
@@ -40,30 +43,55 @@ geom_test_cleanup()
 			echo "# Removing test memory disk: $test_md"
 			mdconfig -d -u $test_md
 		done < $TEST_MDS_FILE
+		rm -f "$TEST_MDS_FILE"
 	fi
-	rm -f "$TEST_MDS_FILE"
 }
 
-if [ $(id -u) -ne 0 ]; then
-	echo '1..0 # SKIP tests must be run as root'
-	exit 0
-fi
+geom_verify_temp_mds_file_existence()
+{
+	if [ ! -f $TEST_MDS_FILE ]; then
+		echo "test md(4) devices file creation unsuccessful"
+		return 1
+	fi
+}
 
-# If the geom class isn't already loaded, try loading it.
-if ! kldstat -q -m g_${class}; then
-	if ! geom ${class} load; then
-		echo "1..0 # SKIP could not load module for geom class=${class}"
+geom_load_class_if_needed()
+{
+	local class=$1
+
+	# If the geom class isn't already loaded, try loading it.
+	if ! kldstat -q -m g_${class}; then
+		if ! geom ${class} load; then
+			echo "could not load module for geom class=${class}"
+			return 1
+		fi
+	fi
+	return 0
+}
+
+geom_atf_test_setup()
+{
+	if ! error_message=$(geom_verify_temp_mds_file_existence); then
+		atf_skip "$error_message"
+	fi
+	if ! error_message=$(geom_load_class_if_needed $class); then
+		atf_skip "$error_message"
+	fi
+}
+
+geom_tap_test_setup()
+{
+	if ! error_message=$(geom_verify_temp_mds_file_existence); then
+		echo "1..0 # SKIP $error_message"
+		exit 1
+	fi
+	if ! error_message=$(geom_load_class_if_needed $class); then
+		echo "1..0 # SKIP $error_message"
 		exit 0
 	fi
-fi
+}
 
-# Need to keep track of the test md devices to avoid the scenario where a test
-# failing will cause the other tests to bomb out, or a test failing will leave
-# a large number of md(4) devices lingering around
-: ${TMPDIR=/tmp}
-export TMPDIR
-if ! TEST_MDS_FILE=$(mktemp ${TMPDIR}/test_mds.XXXXXX); then
-	echo 'Failed to create temporary file for tracking the test md(4) devices'
-	echo 'Bail out!'
-	exit 1
+: ${ATF_TEST=false}
+if ! $ATF_TEST; then
+	geom_tap_test_setup
 fi

--- a/tests/sys/geom/class/mirror/sync_error.sh
+++ b/tests/sys/geom/class/mirror/sync_error.sh
@@ -1,5 +1,8 @@
 # $FreeBSD$
 
+ATF_TEST=true
+. $(atf_get_srcdir)/conf.sh
+
 REG_READ_FP=debug.fail_point.g_mirror_regular_request_read
 
 atf_test_case sync_read_error_2_disks cleanup
@@ -11,7 +14,7 @@ sync_read_error_2_disks_head()
 }
 sync_read_error_2_disks_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geom_atf_test_setup
 
 	f1=$(mktemp ${base}.XXXXXX)
 	f2=$(mktemp ${base}.XXXXXX)
@@ -25,7 +28,7 @@ sync_read_error_2_disks_body()
 	atf_check gmirror label $name $md1
 	devwait
 
-	atf_check -s exit:0 -e empty -o not-empty sysctl ${REG_READ_FP}='1*return(5)'
+	atf_check -s ignore -e empty -o not-empty sysctl ${REG_READ_FP}='1*return(5)'
 
 	# If a read error occurs while synchronizing and the mirror contains
 	# a single active disk, gmirror has no choice but to fail the
@@ -39,9 +42,7 @@ sync_read_error_2_disks_body()
 }
 sync_read_error_2_disks_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
-
-	atf_check -s exit:0 -e empty -o not-empty sysctl ${REG_READ_FP}='off'
+	atf_check -s ignore -e ignore -o ignore sysctl ${REG_READ_FP}='off'
 	gmirror_test_cleanup
 }
 
@@ -54,7 +55,7 @@ sync_read_error_3_disks_head()
 }
 sync_read_error_3_disks_body()
 {
-	. $(atf_get_srcdir)/conf.sh
+	geom_atf_test_setup
 
 	f1=$(mktemp ${base}.XXXXXX)
 	f2=$(mktemp ${base}.XXXXXX)
@@ -97,9 +98,7 @@ sync_read_error_3_disks_body()
 }
 sync_read_error_3_disks_cleanup()
 {
-	. $(atf_get_srcdir)/conf.sh
-
-	atf_check -s exit:0 -e empty -o not-empty sysctl ${REG_READ_FP}='off'
+	atf_check -s ignore -e ignore -o ignore sysctl ${REG_READ_FP}='off'
 	gmirror_test_cleanup
 }
 


### PR DESCRIPTION
The problem with the logic prior to this commit was twofold:
1. The wrong set of idioms (TAP-compatible) were being applied to the ATF
   testcases when run, resulting in confusing ATF failure results on
   setup.
2. The cleanup subroutines were broken when the geom classes could not be
   loaded as they exited with 0 unexpectedly.

The fixes changes the test code to source the class-specific configuration
(conf.sh) once globally, instead of sourcing it per testcase and per cleanup
subroutine, and to call the ATF-specific setup subroutine(s) inline in
the testcases.

The refactoring done is effectively a no-op for the TAP testcases,
modulo any refactoring done to create common code between the ATF and
TAP testcases.

This unbreaks the geli testcases converted to ATF in r327662 and r327683,
and the gmirror testcases added in r327780, respectively, when the geom
class could not be loaded.

tests/sys/geom/class/mirror/...:
While here, ignore errors when turning debug failpoint sysctl off, which
could occur if the gmirror class was not loaded.

Submitted by: ngie

Test Plan:

Before:
```
     * Test program: /usr/tests/sys/geom/class/eli/attach_test
     * Result: broken: Premature exit; test case exited with code 0
     * Start time: 2018-11-28T03:03:10.053697Z
     * End time: 2018-11-28T03:03:10.083744Z
     * Duration: 0.030s
     * Execution context

Metadata

     * allowed_architectures =
     * allowed_platforms =
     * description = geli attach -d will cause the provider to detach on last close
     * has_cleanup = true
     * is_exclusive = false
     * required_configs =
     * required_disk_space = 0
     * required_files =
     * required_memory = 0
     * required_programs =
     * required_user = root
     * timeout = 300

Standard output

 1..0 # SKIP could not load module for geom class=eli
 1..0 # SKIP could not load module for geom class=eli

Standard error

 geom: Invalid class name 'eli'.
 geom: Invalid class name 'eli'.
```

After (the classes are not loaded):
```
$ sudo kyua test -k /usr/tests/sys/geom/class/Kyuafile
...
eli/setkey_test:setkey  ->  skipped: could not load module for geom class=eli  [0.022s]
eli/setkey_test:setkey_readonly  ->  skipped: could not load module for geom class=eli  [0.035s]
...
mirror/8_test:main  ->  skipped: could not load module for geom class=mirror  [0.011s]
mirror/9_test:main  ->  skipped: could not load module for geom class=mirror  [0.010s]
mirror/sync_error:sync_read_error_2_disks  ->  skipped: could not load module for geom class=mirror  [0.040s]
mirror/sync_error:sync_read_error_3_disks  ->  skipped: could not load module for geom class=mirror  [0.020s]
...
uzip/1_test:main  ->  skipped: could not load module for geom class=uzip  [0.010s]
...
79/79 passed (0 failed)
$
```

After (the classes are loaded by the testcases organically):
```
$ sudo kyua test -k /usr/tests/sys/geom/Kyuafile
class/concat/1_test:main  ->  passed  [0.090s]
class/concat/2_test:main  ->  passed  [0.276s]
class/eli/attach_test:attach_d  ->  passed  [2.206s]
class/eli/attach_test:attach_r  ->  passed  [0.071s]
class/eli/attach_test:nokey  ->  passed  [0.052s]
class/eli/configure_test:configure_b_B  ->  passed  [0.196s]
class/eli/delkey_test:delkey  ->  passed  [0.255s]
class/eli/delkey_test:delkey_readonly  ->  passed  [0.074s]
class/eli/detach_test:detach_l  ->  passed  [2.216s]
class/eli/init_test:init  ->  passed  [8.953s]
class/eli/init_test:init_B  ->  passed  [0.177s]
...
```