### PR TITLE
Conditionally install /etc/rc.d/audit* based on ${MK_AUDIT}

### DIFF
--- a/libexec/rc/rc.d/Makefile
+++ b/libexec/rc/rc.d/Makefile
@@ -15,8 +15,6 @@ CONFS=	DAEMON \
 	addswap \
 	adjkerntz \
 	archdep \
-	auditd \
-	auditdistd \
 	bgfsck \
 	${_blacklistd} \
 	${_bluetooth} \
@@ -162,6 +160,12 @@ APM+=		apm
 APM+=		apmd
 .endif
 APMPACKAGE=	apm
+.endif
+
+.if ${MK_AUDIT} != "no"
+CONFGROUPS+=	AUDIT
+AUDIT+=		auditd
+AUDIT+=		auditdistd
 .endif
 
 .if ${MK_AUTOFS} != "no"

--- a/tools/build/mk/OptionalObsoleteFiles.inc
+++ b/tools/build/mk/OptionalObsoleteFiles.inc
@@ -147,6 +147,8 @@ OLD_FILES+=usr/share/man/man3/unistruct.3.gz
 .endif
 
 .if ${MK_AUDIT} == no
+OLD_FILES+=etc/rc.d/auditd
+OLD_FILES+=etc/rc.d/auditdistd
 OLD_FILES+=usr/sbin/audit
 OLD_FILES+=usr/sbin/auditd
 OLD_FILES+=usr/sbin/auditdistd


### PR DESCRIPTION
/usr/sbin/audit(dist)?d are only installed if ${MK_AUDIT} == yes. Their
supporting scripts should only be installed in those instances as well.

Noted in code review with asomers@.

Submitted by:	ngie

Test Plan:

```
$ cd /usr/src
$ env make -C libexec/rc/rc.d -VAUDIT -VMK_AUDIT

no
$ env SRCCONF=/dev/null make -C libexec/rc/rc.d -VAUDIT -VMK_AUDIT
auditd auditdistd
yes

$ make check-old | grep /etc/rc.d/audit
/etc/rc.d/auditd
/etc/rc.d/auditdistd
$ sudo make delete-old
 # Only deleted /etc/rc.d/audit*
$ rcorder /etc/rc.d/* >/dev/null
rcorder: file `/etc/rc.d/nisdomain' is before unknown provision `ypxfrd'
rcorder: file `/etc/rc.d/nisdomain' is before unknown provision `ypserv'
rcorder: file `/etc/rc.d/nisdomain' is before unknown provision `ypbind'
rcorder: requirement `ipfw' in file `/etc/rc.d/netwait' has no providers.
rcorder: requirement `ipfw' in file `/etc/rc.d/NETWORKING' has no providers.
rcorder: requirement `ypset' in file `/etc/rc.d/automountd' has no providers.
rcorder: requirement `ypset' in file `/etc/rc.d/keyserv' has no providers.
rcorder: requirement `ypset' in file `/etc/rc.d/quota' has no providers.
rcorder: requirement `ipfw' in file `/etc/rc.d/securelevel' has no providers.
```