### PR TITLE
Fix bug on bhyve for Ryzen 1700

### DIFF
--- a/sys/x86/include/specialreg.h
+++ b/sys/x86/include/specialreg.h
@@ -1071,6 +1071,7 @@
 #define	MSR_VM_HSAVE_PA 0xc0010117	/* SVM: host save area address */
 #define	MSR_AMD_CPUID07	0xc0011002	/* CPUID 07 %ebx override */
 #define	MSR_EXTFEATURES	0xc0011005	/* Extended CPUID Features override */
+#define	MSR_AMD_LS_CFG	0xc0011020
 #define	MSR_IC_CFG	0xc0011021	/* Instruction Cache Configuration */
 
 /* MSR_VM_CR related */

--- a/usr.sbin/bhyve/xmsr.c
+++ b/usr.sbin/bhyve/xmsr.c
@@ -89,6 +89,10 @@ emulate_wrmsr(struct vmctx *ctx, int vcpu, uint32_t num, uint64_t val)
 			/* Ignore writes to the PerfCtr MSRs */
 			return (0);
 
+		case MSR_AMD_LS_CFG:
+			/* Ignore writes to the Errata MSRs */
+			return (0);
+				
 		case MSR_P_STATE_CONTROL:
 			/* Ignore write to change the P-state */
 			return (0);


### PR DESCRIPTION
Hello everyone,
I keep having a fairly high cpu usage coming from bhyve when running on freenas.

My logs for `middlewared` in FreeNAS look like this:

```
[2019/03/03 06:11:12] (DEBUG) VMService.run():287 - ned: wrmsr to register 0xc0011020(0) on vcpu 1
[2019/03/03 06:11:12] (DEBUG) VMService.run():287 - ned: wrmsr to register 0xc0011020(0x400) on vcpu 6
[2019/03/03 06:11:12] (DEBUG) VMService.run():287 - ned: wrmsr to register 0xc0011020(0) on vcpu 7
[2019/03/03 06:11:12] (DEBUG) VMService.run():287 - ned: wrmsr to register 0xc0011020(0) on vcpu 3
[2019/03/03 06:11:12] (DEBUG) VMService.run():287 - ned: wrmsr to register 0xc0011020(0) on vcpu 6
```

I traced it to the following lines and came up with this patch.
I am not fully sure whether this will truly solve the problem.

Any guidance on how to test this locally is welcome :)

More details [in this forum post](https://www.ixsystems.com/community/threads/high-cpu-usage-on-ryzen-1700.74318/)