### PR TITLE
Remove an unnecessary comparison operation when nprocs_new < maxproc - 10

### DIFF
--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -883,7 +883,7 @@ fork1(struct thread *td, struct fork_req *fr)
 	 * processes; don't let root exceed the limit.
 	 */
 	nprocs_new = atomic_fetchadd_int(&nprocs, 1) + 1;
-	if (nprocs_new >= maxproc - 10)
+	if (nprocs_new >= maxproc - 10) {
 		if (priv_check_cred(td->td_ucred, PRIV_MAXPROC) != 0 ||
 		    nprocs_new >= maxproc) {
 			error = EAGAIN;
@@ -896,6 +896,7 @@ fork1(struct thread *td, struct fork_req *fr)
 			sx_xunlock(&allproc_lock);
 			goto fail2;
 		}
+	}
 
 	/*
 	 * If required, create a process descriptor in the parent first; we

--- a/sys/kern/kern_fork.c
+++ b/sys/kern/kern_fork.c
@@ -883,19 +883,19 @@ fork1(struct thread *td, struct fork_req *fr)
 	 * processes; don't let root exceed the limit.
 	 */
 	nprocs_new = atomic_fetchadd_int(&nprocs, 1) + 1;
-	if ((nprocs_new >= maxproc - 10 &&
-	    priv_check_cred(td->td_ucred, PRIV_MAXPROC) != 0) ||
-	    nprocs_new >= maxproc) {
-		error = EAGAIN;
-		sx_xlock(&allproc_lock);
-		if (ppsratecheck(&lastfail, &curfail, 1)) {
-			printf("maxproc limit exceeded by uid %u (pid %d); "
-			    "see tuning(7) and login.conf(5)\n",
-			    td->td_ucred->cr_ruid, p1->p_pid);
+	if (nprocs_new >= maxproc - 10)
+		if (priv_check_cred(td->td_ucred, PRIV_MAXPROC) != 0 ||
+		    nprocs_new >= maxproc) {
+			error = EAGAIN;
+			sx_xlock(&allproc_lock);
+			if (ppsratecheck(&lastfail, &curfail, 1)) {
+				printf("maxproc limit exceeded by uid %u (pid %d); "
+				    "see tuning(7) and login.conf(5)\n",
+				    td->td_ucred->cr_ruid, p1->p_pid);
+			}
+			sx_xunlock(&allproc_lock);
+			goto fail2;
 		}
-		sx_xunlock(&allproc_lock);
-		goto fail2;
-	}
 
 	/*
 	 * If required, create a process descriptor in the parent first; we


### PR DESCRIPTION
In the original code even if nprocs_new < maxproc -10, the program will still want to test if nprocs_new >= maxproc. That test is not necessary.
With the new code the unnecessary test will be eliminated and the generated assembly code is smaller.