### PR TITLE
fix i386 msun cexp tests

### DIFF
--- a/lib/msun/tests/cexp_test.c
+++ b/lib/msun/tests/cexp_test.c
@@ -66,6 +66,15 @@ __FBSDID("$FreeBSD$");
 	assert(((void)(func), fetestexcept(exceptmask) == (excepts)));	\
 } while (0)
 
+#define test_c(t, func, z, result, exceptmask, excepts, checksign) do { \
+        volatile t complex r = result;                                  \
+        test(func, z, r, exceptmask, excepts, checksign);               \
+} while (0)
+
+#define test_f(func, z, result, exceptmask, excepts, checksign) do {    \
+        test_c(float, func, z, result, exceptmask, excepts, checksign); \
+} while (0)
+
 /* Test within a given tolerance. */
 #define	test_tol(func, z, result, tol)				do {	\
 	volatile long double complex _d = z;				\
@@ -76,7 +85,7 @@ __FBSDID("$FreeBSD$");
 /* Test all the functions that compute cexp(x). */
 #define	testall(x, result, exceptmask, excepts, checksign)	do {	\
 	test(cexp, x, result, exceptmask, excepts, checksign);		\
-	test(cexpf, x, result, exceptmask, excepts, checksign);		\
+	test_f(cexpf, x, result, exceptmask, excepts, checksign);		\
 } while (0)
 
 /*
@@ -198,10 +207,10 @@ test_reals(void)
 		test(cexp, CMPLXL(finites[i], -0.0),
 		     CMPLXL(exp(finites[i]), -0.0),
 		     FE_INVALID | FE_DIVBYZERO, 0, 1);
-		test(cexpf, CMPLXL(finites[i], 0.0),
+		test_f(cexpf, CMPLXL(finites[i], 0.0),
 		     CMPLXL(expf(finites[i]), 0.0),
 		     FE_INVALID | FE_DIVBYZERO, 0, 1);
-		test(cexpf, CMPLXL(finites[i], -0.0),
+		test_f(cexpf, CMPLXL(finites[i], -0.0),
 		     CMPLXL(expf(finites[i]), -0.0),
 		     FE_INVALID | FE_DIVBYZERO, 0, 1);
 	}
@@ -220,10 +229,10 @@ test_imaginaries(void)
 		test(cexp, CMPLXL(-0.0, finites[i]),
 		     CMPLXL(cos(finites[i]), sin(finites[i])),
 		     ALL_STD_EXCEPT & ~FE_INEXACT, 0, 1);
-		test(cexpf, CMPLXL(0.0, finites[i]),
+		test_f(cexpf, CMPLXL(0.0, finites[i]),
 		     CMPLXL(cosf(finites[i]), sinf(finites[i])),
 		     ALL_STD_EXCEPT & ~FE_INEXACT, 0, 1);
-		test(cexpf, CMPLXL(-0.0, finites[i]),
+		test_f(cexpf, CMPLXL(-0.0, finites[i]),
 		     CMPLXL(cosf(finites[i]), sinf(finites[i])),
 		     ALL_STD_EXCEPT & ~FE_INEXACT, 0, 1);
 	}
@@ -302,12 +311,8 @@ main(void)
 	test_inf();
 	printf("ok 3 - cexp inf\n");
 
-#if defined(__i386__)
-	printf("not ok 4 - cexp reals # TODO: PR # 191676 fails assertion on i386\n");
-#else
 	test_reals();
 	printf("ok 4 - cexp reals\n");
-#endif
 
 	test_imaginaries();
 	printf("ok 5 - cexp imaginaries\n");

--- a/lib/msun/tests/cexp_test.c
+++ b/lib/msun/tests/cexp_test.c
@@ -85,7 +85,7 @@ __FBSDID("$FreeBSD$");
 /* Test all the functions that compute cexp(x). */
 #define	testall(x, result, exceptmask, excepts, checksign)	do {	\
 	test(cexp, x, result, exceptmask, excepts, checksign);		\
-	test_f(cexpf, x, result, exceptmask, excepts, checksign);		\
+	test_f(cexpf, x, result, exceptmask, excepts, checksign);	\
 } while (0)
 
 /*


### PR DESCRIPTION
adding another volatile helped
only tested on openbsd (with freebsds libm tho)