### PR TITLE
Correctly use BASEDIR when checking for src component

### DIFF
--- a/usr.sbin/freebsd-update/freebsd-update.sh
+++ b/usr.sbin/freebsd-update/freebsd-update.sh
@@ -222,7 +222,15 @@ config_KeepModifiedMetadata () {
 config_Components () {
 	for C in $@; do
 		if [ "$C" = "src" ]; then
-			if [ -e "${BASEDIR}/usr/src/COPYRIGHT" ]; then
+			if [ -n "${BASEDIR}" ]; then
+				basedir="${BASEDIR}/"
+			elif [ -n "${BASEDIR_saved}" ]; then
+				basedir="${BASEDIR_saved}/"
+			else
+				basedir="/"
+			fi
+
+			if [ -e "${basedir}usr/src/COPYRIGHT" ]; then
 				COMPONENTS="${COMPONENTS} ${C}"
 			else
 				echo "src component not installed, skipped"


### PR DESCRIPTION
BASEDIR is used to check to ensure we check sources in the right place as outlined by https://github.com/freebsd/freebsd/commit/ba040f8c3494b8eb245b20efe57ad591fec5613e#diff-7d334bdfcbfcd070ed2c6a35ada63787.
Problem is that when this function is called, BASEDIR is empty because we set it to empty while reading conffile. This change ensures that if basedir is specified in conffile, that is used, if not then command line argument
is checked and if that is not present as well then we default to /. Came across this at https://github.com/iocage/iocage/issues/892.