### PR TITLE
off is zero. It can be removed.

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -610,8 +610,7 @@ __elfN(load_section)(struct image_params *imgp, vm_ooffset_t offset,
 	 * segment in the file is extended to provide bss.  It's a neat idea
 	 * to try and save a page, but it's a pain in the behind to implement.
 	 */
-	copy_len = filsz == 0 ? 0 : (offset + filsz) - trunc_page(offset +
-	    filsz);
+	copy_len = filsz == 0 ? 0 : (offset + filsz) & PAGE_MASK;
 	map_addr = trunc_page((vm_offset_t)vmaddr + filsz);
 	map_len = round_page((vm_offset_t)vmaddr + memsz) - map_addr;
 

--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -550,7 +550,7 @@ __elfN(load_section)(struct image_params *imgp, vm_ooffset_t offset,
 	size_t map_len;
 	vm_map_t map;
 	vm_object_t object;
-	vm_offset_t off, map_addr;
+	vm_offset_t map_addr;
 	int error, rv, cow;
 	size_t copy_len;
 	vm_ooffset_t file_addr;
@@ -629,8 +629,7 @@ __elfN(load_section)(struct image_params *imgp, vm_ooffset_t offset,
 			return (EIO);
 
 		/* send the page fragment to user space */
-		off = trunc_page(offset + filsz) - trunc_page(offset + filsz);
-		error = copyout((caddr_t)sf_buf_kva(sf) + off,
+		error = copyout((caddr_t)sf_buf_kva(sf),
 		    (caddr_t)map_addr, copy_len);
 		vm_imgact_unmap_page(sf);
 		if (error != 0)


### PR DESCRIPTION
off = trunc_page(offset + filsz) - trunc_page(offset + filsz) and it is zero.