### PR TITLE
Do not left-shift by a negative number (inducing undefined behavior in C/C++) in exp/expf during intermediate computations that compute the IEEE-754 bit pattern for |2**k| for integer |k|

### DIFF
--- a/lib/msun/src/e_exp.c
+++ b/lib/msun/src/e_exp.c
@@ -145,9 +145,9 @@ __ieee754_exp(double x)	/* default IEEE double exp */
     /* x is now in primary range */
 	t  = x*x;
 	if(k >= -1021)
-	    INSERT_WORDS(twopk,0x3ff00000+(k<<20), 0);
+	    INSERT_WORDS(twopk,((u_int32_t)(0x3ff+k))<<20, 0);
 	else
-	    INSERT_WORDS(twopk,0x3ff00000+((k+1000)<<20), 0);
+	    INSERT_WORDS(twopk,((u_int32_t)(0x3ff+(k+1000)))<<20, 0);
 	c  = x - t*(P1+t*(P2+t*(P3+t*(P4+t*P5))));
 	if(k==0) 	return one-((x*c)/(c-2.0)-x); 
 	else 		y = one-((lo-(x*c)/(2.0-c))-hi);

--- a/lib/msun/src/e_expf.c
+++ b/lib/msun/src/e_expf.c
@@ -83,9 +83,9 @@ __ieee754_expf(float x)
     /* x is now in primary range */
 	t  = x*x;
 	if(k >= -125)
-	    SET_FLOAT_WORD(twopk,0x3f800000+(k<<23));
+	    SET_FLOAT_WORD(twopk,((u_int32_t)(0x7f+k))<<23);
 	else
-	    SET_FLOAT_WORD(twopk,0x3f800000+((k+100)<<23));
+	    SET_FLOAT_WORD(twopk,((u_int32_t)(0x7f+(k+100)))<<23);
 	c  = x - t*(P1+t*P2);
 	if(k==0) 	return one-((x*c)/(c-(float)2.0)-x);
 	else 		y = one-((lo-(x*c)/((float)2.0-c))-hi);


### PR DESCRIPTION
The implementations of `exp`/`expf` need to compute IEEE-754 bit patterns for `2**k` in certain places.  (`k` is an integer and `2**k` is exactly representable in IEEE-754.)

Currently they do things like `0x3FF0'0000+(k<<20)`, which is to say they take the bit pattern representing `1` and then add directly to the exponent field to get the desired power of two.  This is fine when `k` is non-negative.

But when `k<0` (and certain classes of input trigger this), this left-shifts a negative number -- an operation with undefined behavior in C and C++.

The desired semantics can be achieved by instead adding the possibly-negative `k` to the IEEE-754 exponent bias to get the desired exponent field, _then_ shifting that into its proper overall position.

These patches seem to do the right thing for me in manually testing them out in Mozilla's SpiderMonkey JavaScript engine (which imports fdlibm for a bunch of its math operations).  But this is obviously delicate code, so extra care in reviewing these proposed changes is appreciated.  😅

(In mildly related vein, see also https://github.com/freebsd/freebsd/pull/130 for a prior UB issue in fdlibm we stumbled across and submitted for upstream reviewing/fixing.  Also note that I'll shortly be filing [an issue](https://github.com/freebsd/freebsd/pull/412) for this same problem in fdlibm's `expm1`/`expm1f` functions.)