### PR TITLE
Do not left-shift by a negative number (inducing undefined behavior in C/C++) in expm1/expm1f during intermediate computations that compute the IEEE-754 bit pattern for |2**k| for integer |k|

### DIFF
--- a/lib/msun/src/s_expm1.c
+++ b/lib/msun/src/s_expm1.c
@@ -188,7 +188,7 @@ expm1(double x)
 	e  = hxs*((r1-t)/(6.0 - x*t));
 	if(k==0) return x - (x*e-hxs);		/* c is 0 */
 	else {
-	    INSERT_WORDS(twopk,0x3ff00000+(k<<20),0);	/* 2^k */
+	    INSERT_WORDS(twopk,((u_int32_t)(0x3ff+k))<<20,0);	/* 2^k */
 	    e  = (x*(e-c)-c);
 	    e -= hxs;
 	    if(k== -1) return 0.5*(x-e)-0.5;

--- a/lib/msun/src/s_expm1f.c
+++ b/lib/msun/src/s_expm1f.c
@@ -94,7 +94,7 @@ expm1f(float x)
 	e  = hxs*((r1-t)/((float)6.0 - x*t));
 	if(k==0) return x - (x*e-hxs);		/* c is 0 */
 	else {
-	    SET_FLOAT_WORD(twopk,0x3f800000+(k<<23));	/* 2^k */
+	    SET_FLOAT_WORD(twopk,((u_int32_t)(0x7f+k))<<23);	/* 2^k */
 	    e  = (x*(e-c)-c);
 	    e -= hxs;
 	    if(k== -1) return (float)0.5*(x-e)-(float)0.5;


### PR DESCRIPTION
The implementations of `expm1`/`expm1f` need to compute IEEE-754 bit patterns for `2**k` in certain places.  (`k` is an integer and `2**k` is exactly representable in IEEE-754.)

Currently they do things like `0x3FF0'0000+(k<<20)`, which is to say they take the bit pattern representing `1` and then add directly to the exponent field to get the desired power of two.  This is fine when `k` is non-negative.

But when `k<0` (and certain classes of input trigger this), this left-shifts a negative number -- an operation with undefined behavior in C and C++.

The desired semantics can be achieved by instead adding the possibly-negative `k` to the IEEE-754 exponent bias to get the desired exponent field, _then_ shifting that into its proper overall position.

(Note that there are `SET_HIGH_WORD`/`SET_FLOAT_WORD` uses further down in each of these files that perform shift operations involving `k`, but by these points `k`'s range has been restricted to `2 < k <= 56`, and the shift operations under those circumstances can't do anything that would be UB.)

These patches seem to do the right thing for me in manually testing them out in Mozilla's SpiderMonkey JavaScript engine (which imports fdlibm for a bunch of its math operations).  But this is obviously delicate code, so extra care in reviewing these proposed changes is appreciated.  😅

(In mildly related vein, see also https://github.com/freebsd/freebsd/pull/130 for a prior UB issue in fdlibm we stumbled across and submitted for upstream reviewing/fixing.  Also note that I just filed [an issue](https://github.com/freebsd/freebsd/pull/411) for this same problem in fdlibm's `exp`/`expf` functions.)