### PR TITLE
Don't left-shift negative numbers in certain circumstances in the various fdlibm hypot() functions

### DIFF
--- a/lib/msun/src/e_hypot.c
+++ b/lib/msun/src/e_hypot.c
@@ -118,10 +118,9 @@ __ieee754_hypot(double x, double y)
 	    w  = sqrt(t1*y1-(w*(-w)-(t1*y2+t2*b)));
 	}
 	if(k!=0) {
-	    u_int32_t high;
-	    t1 = 1.0;
-	    GET_HIGH_WORD(high,t1);
-	    SET_HIGH_WORD(t1,high+(k<<20));
+	    int32_t exponent = 1023 + k;
+	    t1 = 0.0;
+	    SET_HIGH_WORD(t1,exponent<<20);
 	    return t1*w;
 	} else return w;
 }

--- a/lib/msun/src/e_hypotf.c
+++ b/lib/msun/src/e_hypotf.c
@@ -77,7 +77,7 @@ __ieee754_hypotf(float x, float y)
 	    w  = __ieee754_sqrtf(t1*y1-(w*(-w)-(t1*y2+t2*b)));
 	}
 	if(k!=0) {
-	    SET_FLOAT_WORD(t1,0x3f800000+(k<<23));
+	    SET_FLOAT_WORD(t1,(127+k)<<23);
 	    return t1*w;
 	} else return w;
 }

--- a/lib/msun/src/e_hypotl.c
+++ b/lib/msun/src/e_hypotl.c
@@ -115,10 +115,8 @@ hypotl(long double x, long double y)
 	    w  = sqrtl(t1*y1-(w*(-w)-(t1*y2+t2*b)));
 	}
 	if(k!=0) {
-	    u_int32_t high;
-	    t1 = 1.0;
-	    GET_HIGH_WORD(high,t1);
-	    SET_HIGH_WORD(t1,high+DESW(k));
+	    t1 = 0;
+	    SET_HIGH_WORD(t1, ESW(k)); /* t1=2^k */
 	    return t1*w;
 	} else return w;
 }


### PR DESCRIPTION
Various paths through `hypot(x, y)` will multiply `x` and `y` by a power of two, perform the calculation in a range where IEEE-754 provides greater precision, then undo the multiplication to determine the true result.  Undoing that multiplication is implemented as `t1*w`, where `t1=2**k`.

`2**k` is often computed by taking the high word of `1.0`, then adding `k<<20` (for doubles or long doubles) or `k<<23` (for floats) to it, then overwriting that high word.  But when `k` is negative this left-shifts a negative value -- and that's undefined behavior in many editions of C and C++.

This patch should fix all `hypot` implementations to compute `2**k` without triggering this particular bit of undefined behavior.  I've only _very lightly_ tested out the `double` change, in SpiderMonkey's JavaScript engine; the other functions' changes have more or less only been eyeballed.  I am also unsure whether the particular ways of spelling things out here are stylistically preferred; the fdlibm code has all sorts of magic numbers in it, and few idioms for hiding them away behind structured access functions, so the desired idioms are not entirely obvious.  Careful examination appreciated!