### PR TITLE
Update vm_map.c

### DIFF
--- a/sys/vm/vm_map.c
+++ b/sys/vm/vm_map.c
@@ -4687,7 +4687,7 @@ vm_map_lookup(vm_map_t *var_map,		/* IN/OUT */
 	vm_map_entry_t entry;
 	vm_map_t map = *var_map;
 	vm_prot_t prot;
-	vm_prot_t fault_type = fault_typea;
+	vm_prot_t fault_type/* = fault_typea*/;
 	vm_object_t eobject;
 	vm_size_t size;
 	struct ucred *cred;
@@ -4731,7 +4731,8 @@ RetryLookupLocked:
 		    vm_map_growstack(map, vaddr, entry) == KERN_SUCCESS)
 			goto RetryLookupLocked;
 	}
-	fault_type &= VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE;
+	fault_type = fault_typea & 
+	    (VM_PROT_READ | VM_PROT_WRITE | VM_PROT_EXECUTE);
 	if ((fault_type & prot) != fault_type || prot == VM_PROT_NONE) {
 		vm_map_unlock_read(map);
 		return (KERN_PROTECTION_FAILURE);


### PR DESCRIPTION
Should fault_type be initialized here since fault_type will be changed if the entry is wired and the program decided to jump to RetryLookup*? That is if the entry is wired entry, fault_type will be changed. But if the program later decides to jump to RetryLockup*, then the original contents from fault_typea will be lost.