### PR TITLE
Remove redundant code in __elfN(map_insert)

### DIFF
--- a/sys/kern/imgact_elf.c
+++ b/sys/kern/imgact_elf.c
@@ -600,7 +600,7 @@ __elfN(load_section)(struct image_params *imgp, vm_ooffset_t offset,
 	}
 
 	/*
-	 * If the code reaches here it means that this is a data section and
+	 * If the program reaches here it means that this is a data section and
 	 * data section always has WRITE permission.
 	 */
 	if ((prot & VM_PROT_WRITE) == 0)

--- a/sys/sys/errno.h
+++ b/sys/sys/errno.h
@@ -48,6 +48,7 @@ __END_DECLS
 #define	errno		(* __error())
 #endif
 
+#define	ESUCCESS	0		/* Operation success */
 #define	EPERM		1		/* Operation not permitted */
 #define	ENOENT		2		/* No such file or directory */
 #define	ESRCH		3		/* No such process */

--- a/sys/sys/errno.h
+++ b/sys/sys/errno.h
@@ -48,7 +48,9 @@ __END_DECLS
 #define	errno		(* __error())
 #endif
 
+#ifndef _POSIX_SOURCE
 #define	ESUCCESS	0		/* Operation success */
+#endif
 #define	EPERM		1		/* Operation not permitted */
 #define	ENOENT		2		/* No such file or directory */
 #define	ESRCH		3		/* No such process */


### PR DESCRIPTION
Also
* Do more check on the executable file.
* Add a new error return constant ESUCCESS to make the return code more clear.