### PR TITLE
MTU wasn't initialized

### DIFF
--- a/sys/dev/qlxgb/qla_os.c
+++ b/sys/dev/qlxgb/qla_os.c
@@ -673,6 +673,8 @@ qla_init_ifnet(device_t dev, qla_host_t *ha)
 	if_initname(ifp, device_get_name(dev), device_get_unit(dev));
 
 	ifp->if_baudrate = IF_Gbps(10);
+	ifp->if_mtu = ETHERMTU;
+
 	ifp->if_init = qla_init;
 	ifp->if_softc = ha;
 	ifp->if_flags = IFF_BROADCAST | IFF_SIMPLEX | IFF_MULTICAST;


### PR DESCRIPTION
Fix these error:
ql1: qla_hw_send: (nsegs[1, 42, 0x0] > Q8_TX_MAX_SEGMENTS)
ql1: qla_dump_buf8: qla_hw_send: wrong pkt 0x2a dump start
ql1: 0x00000000: ff ff ff ff ff ff 24 be 05 ef 32 44 08 06 00 01
ql1: 0x00000010: 08 00 06 04 00 01 24 be 05 ef 32 44 ac 10 06 01
ql1: 0x00000020: 00 00 00 00 00 00 ac 10 06 01
ql1: qla_dump_buf8: qla_hw_send: wrong pkt dump end

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=226217
https://redmine.ixsystems.com/issues/14925
