### PR TITLE
asmc: handle asmc_key_read() error

### DIFF
--- a/sys/dev/asmc/asmc.c
+++ b/sys/dev/asmc/asmc.c
@@ -1067,7 +1067,7 @@ asmc_fan_count(device_t dev)
 {
 	uint8_t buf[1];
 
-	if (asmc_key_read(dev, ASMC_KEY_FANCOUNT, buf, sizeof buf) < 0)
+	if (asmc_key_read(dev, ASMC_KEY_FANCOUNT, buf, sizeof buf))
 		return (-1);
 
 	return (buf[0]);
@@ -1081,7 +1081,7 @@ asmc_fan_getvalue(device_t dev, const char *key, int fan)
 	char fankey[5];
 
 	snprintf(fankey, sizeof(fankey), key, fan);
-	if (asmc_key_read(dev, fankey, buf, sizeof buf) < 0)
+	if (asmc_key_read(dev, fankey, buf, sizeof buf))
 		return (-1);
 	speed = (buf[0] << 6) | (buf[1] >> 2);
 
@@ -1095,7 +1095,7 @@ asmc_fan_getstring(device_t dev, const char *key, int fan, uint8_t *buf, uint8_t
 	char* desc;
 
 	snprintf(fankey, sizeof(fankey), key, fan);
-	if (asmc_key_read(dev, fankey, buf, buflen) < 0)
+	if (asmc_key_read(dev, fankey, buf, buflen))
 		return (NULL);
 	desc = buf+4;
 
@@ -1234,7 +1234,7 @@ asmc_temp_getvalue(device_t dev, const char *key)
 	/*
 	 * Check for invalid temperatures.
 	 */
-	if (asmc_key_read(dev, key, buf, sizeof buf) < 0)
+	if (asmc_key_read(dev, key, buf, sizeof buf))
 		return (-1);
 
 	return (buf[0]);


### PR DESCRIPTION
Hi,
asmc_key_read() return 1 and 0 only, some callers are checking using <0
for failure