### PR TITLE
pci/ich handle ich_init() error

### DIFF
--- a/sys/dev/sound/pci/ich.c
+++ b/sys/dev/sound/pci/ich.c
@@ -1191,15 +1191,17 @@ ich_pci_resume(device_t dev)
 {
 	struct sc_info *sc;
 	int i;
+	int err;
 
 	sc = pcm_getdevinfo(dev);
 
 	ICH_LOCK(sc);
 	/* Reinit audio device */
-    	if (ich_init(sc) == -1) {
+	err = ich_init(sc);
+	if (err != 0) {
 		device_printf(dev, "unable to reinitialize the card\n");
 		ICH_UNLOCK(sc);
-		return (ENXIO);
+		return err;
 	}
 	/* Reinit mixer */
 	ich_pci_codec_reset(sc);


### PR DESCRIPTION
ich_init() can only return 0 and ENXIO(6) and the caller is checking
failure using == -1